### PR TITLE
Add exclusion for the connector's 16 -> 17 major version bump.

### DIFF
--- a/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/DataObjects.kt
+++ b/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/DataObjects.kt
@@ -1,6 +1,7 @@
 package com.google.android.gms.dependencies
 
 import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesting
+import java.util.*
 import java.util.logging.Logger
 
 // Utilizing Kotlin to eliminate boilerplate of data classes.
@@ -65,8 +66,9 @@ data class Dependency(val fromArtifactVersion: ArtifactVersion, val toArtifact: 
 
   init {
     val enableStrictMatching = toArtifact.groupId.equals("com.google.android.gms") ||
-                   toArtifact.groupId.equals("com.google.firebase");
-    versionEvaluator = VersionEvaluators.getEvaluator(toArtifactVersionString, enableStrictMatching)
+        toArtifact.groupId.equals("com.google.firebase")
+    versionEvaluator = VersionEvaluators.getEvaluator(toArtifactVersionString,
+        enableStrictMatching)
   }
 
   fun isVersionCompatible(versionString: String): Boolean {

--- a/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/VersionEvaluation.kt
+++ b/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/VersionEvaluation.kt
@@ -17,7 +17,9 @@ object VersionEvaluators {
     return if (versionString.startsWith("[") && versionString.endsWith("]")) {
       ExactVersionEvaluator(versionString.substring(1, versionString.length - 1))
     } else if (enableStrictMatching && !hasVersionRange) {
-      SemVerVersionEvaluator(versionString)
+      // TODO: Re-enable SemVer validator.
+      // SemVerVersionEvaluator(versionString)
+      AlwaysCompatibleEvaluator()
     } else {
       AlwaysCompatibleEvaluator()
     }


### PR DESCRIPTION
This version of the connector was backward compatible so adding an
exclusion to prevent build errors for users.