### PR TITLE
Handled the root module's display name

### DIFF
--- a/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/DependencyInspector.java
+++ b/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/DependencyInspector.java
@@ -105,7 +105,8 @@ public class DependencyInspector implements DependencyResolutionListener {
       // * depResult.getFrom() == null represents a direct dep from the
       //   project being evaluated.
       if (depResult.getFrom() == null ||
-          "".equals(depResult.getFrom().getId().getDisplayName())) {
+          "".equals(depResult.getFrom().getId().getDisplayName()) ||
+          "project :".equals(depResult.getFrom().getId().getDisplayName())) {
         // Register the dep from the project directly.
         fromDep = ArtifactVersion.Companion.fromGradleRef(
             GRADLE_PROJECT + ":" + projectName + "-" + taskName + ":0.0.0");


### PR DESCRIPTION
The root module's path is ":" and therefore it's display name is "project :".
Calling split(":")[1] on "project :" causes "java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1" to be thrown.