### PR TITLE
Publish plugin marker artifact for google-services-plugin

### DIFF
--- a/google-services-plugin/README.md
+++ b/google-services-plugin/README.md
@@ -2,20 +2,42 @@
 
 This plugin converts the google-services.json file for Firebase into a set of resources that the Firebase libraries can use. It also references the strict-version-matcher plugin, and will execute those checks as well. 
 
-## To use
+## Usage
 
-In your app's build.gradle:
+### Plugins DSL
+
+Add the following to your project's settings.gradle:
 
 ```
-apply plugin: 'com.google.gms.google-services'
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+    }
+}
 ```
 
-In order to use this plugin, you will also need to add the following to your
-buildscript classpath, obtained from Google’s
+Apply the plugin in your app's build.gradle:
+
+```
+plugins {
+    id 'com.google.gms.google-services' version '4.2.0'
+}
+```
+
+## Legacy way
+
+Add the following to your buildscript classpath, obtained from Google’s
 [Maven repository](//developer.android.com/studio/build/dependencies#google-maven):
 
 ```
 classpath 'com.google.gms:google-services:4.2.0'
+```
+
+Apply the plugin in your app's build.gradle:
+
+```
+apply plugin: 'com.google.gms.google-services'
 ```
 
 These instructions are also documented

--- a/google-services-plugin/bintray.gradle
+++ b/google-services-plugin/bintray.gradle
@@ -29,9 +29,9 @@ def BINTRAY_PUBLISH = project.has('bintrayPublish') ? project.ext.bintrayPublish
 def MAVEN_SYNC = false
 def MAVEN_CLOSE = '0'
 
-def BINTRAY_PROJECT_NAME = "${project.ext.group}.${project.ext.archivesBaseName}"
+def BINTRAY_PROJECT_NAME = "${project.group}.${project.ext.archivesBaseName}"
 
-publishing.publications.maven(MavenPublication) {
+publishing.publications.pluginMaven(MavenPublication) {
 
     pom.withXml {
         asNode().appendNode('description', project.ext.pomDesc)
@@ -59,7 +59,7 @@ bintray {
     key = project.ext.bintrayKey
     dryRun = BINTRAY_DRYRUN
     publish = BINTRAY_PUBLISH
-    publications = ['maven']
+    publications = ['pluginMaven']
 
     pkg {
         repo = project.ext.bintrayRepo
@@ -70,8 +70,8 @@ bintray {
         publicDownloadNumbers = true
         vcsUrl = 'git://android.googlesource.com/platform/tools/base.git'
         version {
-            name = project.ext.version
-            desc = project.ext.pomDesc + ' version ' + project.ext.version
+            name = project.version
+            desc = project.ext.pomDesc + ' version ' + project.version
             released  = new java.util.Date()
         }
     }

--- a/google-services-plugin/build.gradle
+++ b/google-services-plugin/build.gradle
@@ -7,16 +7,17 @@ buildscript {
     }
 }
 
-project.ext.group = 'com.google.gms'
+group = 'com.google.gms'
+version = '4.2.0'
 project.ext.archivesBaseName = 'google-services'
-project.ext.version = '4.2.0'
 project.ext.pomDesc = 'Gradle plug-in to build Firebase applications.'
 
 apply plugin: 'groovy'
+apply plugin: 'java-gradle-plugin'
 
 repositories {
-  google()
-  jcenter()
+    google()
+    jcenter()
 }
 
 dependencies {
@@ -26,6 +27,15 @@ dependencies {
     implementation 'com.google.guava:guava:27.0.1-jre'
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:0.42'
+}
+
+gradlePlugin {
+    plugins {
+        googleServicesPlugin {
+            id = 'com.google.gms.google-services'
+            implementationClass = 'com.google.gms.googleservices.GoogleServicesPlugin'
+        }
+    }
 }
 
 apply from: 'publish.gradle'

--- a/google-services-plugin/publish.gradle
+++ b/google-services-plugin/publish.gradle
@@ -23,29 +23,13 @@ task sourcesJar(type: Jar, dependsOn:classes) {
     from sourceSets.main.allSource
 }
 
-artifacts {
-    archives jar
-    archives sourcesJar
-    archives javadocJar
-}
-
 publishing {
     publications {
-        maven(MavenPublication) {
-
-            groupId project.ext.group
+        pluginMaven(MavenPublication) {
             artifactId project.ext.archivesBaseName
-            version project.ext.version
 
-            from components.java
-
-            artifact sourcesJar {
-                classifier "sources"
-            }
-
-            artifact javadocJar {
-                classifier "javadoc"
-            }
+            artifact sourcesJar
+            artifact javadocJar
         }
     }
 }
@@ -53,4 +37,3 @@ publishing {
 publishing.repositories.maven {
     url "$buildDir/repo"
 }
-

--- a/google-services-plugin/src/main/resources/META-INF/gradle-plugins/com.google.gms.google-services.properties
+++ b/google-services-plugin/src/main/resources/META-INF/gradle-plugins/com.google.gms.google-services.properties
@@ -1,1 +1,0 @@
-implementation-class=com.google.gms.googleservices.GoogleServicesPlugin


### PR DESCRIPTION
#50

If this will get merged I can do the same for the other two plugins. `oss-licenses-plugin` would have to be migrated from `maven` to `maven-publish` plugin though.