### PR TITLE
Allow applying google-services plugin in any order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,28 @@
-language: groovy
+language: android
+dist: trusty
+android:
+  components:
+    - android-28
+
+before_install:
+  - mkdir -p $ANDROID_HOME/licenses
+  - echo -e "\n24333f8a63b6825ea9c5514f83c2829b004d1fee" > $ANDROID_HOME/licenses/android-sdk-license
+
 before_cache:
-- rm -f $HOME/.gradle/caches/*
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
 cache:
   directories:
-  - $HOME/.gradle/caches/
-  - $HOME/.gradle/wrapper/
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 
 # Using build matrix support to build the sub-projects
 env:
-  - TEST_DIR=strict-version-matcher-plugin
-  - TEST_DIR=google-services-plugin
+  global:
+    - TERM=dumb
+  matrix:
+    - TEST_DIR=strict-version-matcher-plugin
+    - TEST_DIR=google-services-plugin
 
-script: cd $TEST_DIR && gradle assemble && gradle test
+script: cd $TEST_DIR && ./gradlew assemble test

--- a/google-services-plugin/build.gradle
+++ b/google-services-plugin/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'org.jetbrains.kotlin.jvm' version '1.3.50'
     id 'groovy'
     id 'java-gradle-plugin'
     id 'com.jfrog.bintray' version '1.8.4' apply false
@@ -19,8 +20,11 @@ dependencies {
     implementation 'com.google.android.gms:strict-version-matcher-plugin:1.2.0'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.google.guava:guava:27.0.1-jre'
+
+    testImplementation gradleTestKit()
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:0.42'
+    testImplementation 'org.jetbrains.kotlin:kotlin-stdlib'
 }
 
 gradlePlugin {

--- a/google-services-plugin/build.gradle
+++ b/google-services-plugin/build.gradle
@@ -1,19 +1,13 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-    }
+plugins {
+    id 'groovy'
+    id 'java-gradle-plugin'
+    id 'com.jfrog.bintray' version '1.8.4' apply false
 }
 
 group = 'com.google.gms'
 version = '4.3.2'
 project.ext.archivesBaseName = 'google-services'
 project.ext.pomDesc = 'Gradle plug-in to build Firebase applications.'
-
-apply plugin: 'groovy'
-apply plugin: 'java-gradle-plugin'
 
 repositories {
     google()

--- a/google-services-plugin/src/test/java/com/google/gms/googleservices/GoogleServicesPluginFunctionalTest.kt
+++ b/google-services-plugin/src/test/java/com/google/gms/googleservices/GoogleServicesPluginFunctionalTest.kt
@@ -1,0 +1,99 @@
+package com.google.gms.googleservices
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.util.GradleVersion
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import java.io.File
+
+@RunWith(Parameterized::class)
+class GoogleServicesPluginFunctionalTest(androidPluginVersion: String, private val gradleVersion: String) {
+    @Rule
+    @JvmField
+    val tempFolder = TemporaryFolder()
+
+    private val projectGenerator = TestProjectGenerator(
+        androidPluginVersion = androidPluginVersion,
+        apiLevel = 28,
+        packageName = "com.google.gms.googleservices.test"
+    )
+    private lateinit var projectDir: File
+
+    @Before
+    fun setUp() {
+        projectDir = tempFolder.newFolder("project")
+    }
+
+    @Test
+    fun applicationModule() {
+        projectGenerator.generateAndroidModule(projectDir, "com.android.application")
+
+        val result = buildProject()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":processDebugGoogleServices")?.outcome)
+        assertEquals(TaskOutcome.SUCCESS, result.task(":assembleDebug")?.outcome)
+    }
+
+    @Test
+    fun libraryModule() {
+        projectGenerator.generateAndroidModule(projectDir, "com.android.library")
+
+        val result = buildProject()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":processDebugGoogleServices")?.outcome)
+        assertEquals(TaskOutcome.SUCCESS, result.task(":assembleDebug")?.outcome)
+    }
+
+    private fun buildProject(): BuildResult {
+        return GradleRunner.create()
+            .withGradleVersion(gradleVersion)
+            .withPluginClasspath()
+            .withProjectDir(projectDir)
+            .withArguments(":assembleDebug")
+            .forwardOutput()
+            .build()
+    }
+
+    private data class AndroidPluginVersion(
+        val version: String,
+        val minGradleVersion: GradleVersion
+    ) {
+        constructor(version: String, minGradleVersion: String) : this(version, GradleVersion.version(minGradleVersion))
+    }
+
+    companion object {
+        private val AGP_VERSIONS = arrayOf(
+            AndroidPluginVersion("3.1.4", minGradleVersion = "4.4"),
+            AndroidPluginVersion("3.2.1", minGradleVersion = "4.6"),
+            AndroidPluginVersion("3.3.2", minGradleVersion = "4.10.1"),
+            AndroidPluginVersion("3.4.2", minGradleVersion = "5.1.1"),
+            AndroidPluginVersion("3.5.0", minGradleVersion = "5.4.1")
+        )
+        private val GRADLE_VERSIONS = arrayOf(
+            GradleVersion.version("4.6"),
+            GradleVersion.version("4.10.3"),
+            GradleVersion.version("5.1.1"),
+            GradleVersion.version("5.4.1")
+        )
+
+        @JvmStatic
+        @Parameters(name = "Android Plugin: {0}, Gradle: {1}")
+        fun params(): List<Array<Any>> {
+            return AGP_VERSIONS.asSequence()
+                .flatMap { androidPluginVersion ->
+                    GRADLE_VERSIONS.asSequence()
+                        .filter { gradleVersion -> gradleVersion >= androidPluginVersion.minGradleVersion }
+                        .map { gradleVersion -> arrayOf<Any>(androidPluginVersion.version, gradleVersion.version) }
+                }
+                .toList()
+        }
+    }
+}

--- a/google-services-plugin/src/test/java/com/google/gms/googleservices/TestProjectGenerator.kt
+++ b/google-services-plugin/src/test/java/com/google/gms/googleservices/TestProjectGenerator.kt
@@ -1,0 +1,93 @@
+package com.google.gms.googleservices
+
+import com.google.common.io.Resources
+import java.io.File
+
+class TestProjectGenerator(
+    private val androidPluginVersion: String,
+    private val apiLevel: Int,
+    private val packageName: String
+) {
+    fun generateAndroidModule(projectDir: File, androidPluginId: String) {
+        createBuildGradle(projectDir, androidPluginId)
+        createSettingsGradle(projectDir)
+        createLocalProperties(projectDir)
+        createAndroidManifest(projectDir)
+        copyGoogleServicesJson(projectDir)
+    }
+
+    private fun createBuildGradle(projectDir: File, androidPluginId: String) {
+        val buildGradle = File(projectDir, "build.gradle")
+
+        //language=Groovy
+        buildGradle.writeText(
+            """
+            buildscript {
+                repositories {
+                    google()
+                    jcenter()
+                }
+                dependencies {
+                    classpath 'com.android.tools.build:gradle:$androidPluginVersion'
+                }
+            }
+
+            plugins {
+                id 'com.google.gms.google-services'
+            }
+
+            apply plugin: '$androidPluginId'
+
+            repositories {
+                google()
+                jcenter()
+            }
+
+            android {
+                compileSdkVersion $apiLevel
+
+                defaultConfig {
+                    minSdkVersion 14
+                    targetSdkVersion $apiLevel
+                }
+            }
+        """.trimIndent()
+        )
+    }
+
+    private fun createSettingsGradle(projectDir: File) {
+        projectDir.newFile("settings.gradle").createNewFile()
+    }
+
+    private fun createLocalProperties(projectDir: File) {
+        val androidHome = System.getenv("ANDROID_HOME")
+            ?: throw AssertionError("ANDROID_HOME is not set")
+
+        val localPropertiesFile = projectDir.newFile("local.properties")
+        localPropertiesFile.writeText("sdk.dir=$androidHome")
+    }
+
+    private fun createAndroidManifest(projectDir: File) {
+        val manifestFile = projectDir.newFile("src/main/AndroidManifest.xml")
+        //language=XML
+        manifestFile.writeText(
+            """
+            <manifest package="$packageName" />
+        """.trimIndent()
+        )
+    }
+
+    private fun copyGoogleServicesJson(projectDir: File) {
+        val googleServicesJson = projectDir.newFile("google-services.json")
+        googleServicesJson.outputStream().buffered().use { output ->
+            @Suppress("UnstableApiUsage")
+            Resources.copy(Resources.getResource("mock-google-services.json"), output)
+        }
+    }
+
+    private fun File.newFile(path: String): File {
+        val file = File(this, path)
+        file.parentFile.mkdirs()
+        return file
+    }
+}

--- a/google-services-plugin/src/test/resources/mock-google-services.json
+++ b/google-services-plugin/src/test/resources/mock-google-services.json
@@ -1,0 +1,55 @@
+{
+  "project_info": {
+    "project_number": "123456789000",
+    "firebase_url": "https://mockproject-1234.firebaseio.com",
+    "project_id": "mockproject-1234",
+    "storage_bucket": "mockproject-1234.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:123456789000:android:f1bf012572b04063",
+        "android_client_info": {
+          "package_name": "com.google.gms.googleservices.test"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "123456789000-hjugbg6ud799v4c49dim8ce2usclthar.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.google.gms.googleservices.test",
+            "certificate_hash": []
+          }
+        },
+        {
+          "client_id": "123456789000-hjugbg6ud799v4c49dim8ce2usclthar.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzbSzCn1N6LWIe6wthYyrgUUSAlUsdqMb-wvTo"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 2,
+          "other_platform_oauth_client": [
+            {
+              "client_id": "123456789000-hjugbg6ud799v4c49dim8ce2usclthar.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/oss-licenses-plugin/build.gradle
+++ b/oss-licenses-plugin/build.gradle
@@ -1,5 +1,8 @@
-apply plugin: 'groovy'
-apply plugin: 'java'
+plugins {
+    id 'java'
+    id 'groovy'
+    id 'maven'
+}
 
 dependencies {
     implementation gradleApi()
@@ -11,8 +14,6 @@ dependencies {
 
 group = 'com.google.android.gms'
 version = '0.9.5'
-
-apply plugin: 'maven'
 
 repositories {
     google()

--- a/strict-version-matcher-plugin/build.gradle
+++ b/strict-version-matcher-plugin/build.gradle
@@ -1,19 +1,11 @@
-buildscript {
-    ext.kotlin_version = '1.3.11'
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
+plugins {
+    id 'org.jetbrains.kotlin.jvm' version '1.3.11'
 }
 
 project.ext.group = 'com.google.android.gms'
 project.ext.archivesBaseName = 'strict-version-matcher-plugin'
 project.ext.version = '1.2.0'
 project.ext.pomDesc = 'Gradle plug-in to enforce version ranges for Google Play services and Firebase dependencies.'
-
-apply plugin: 'kotlin'
 
 repositories {
     google()
@@ -26,7 +18,7 @@ dependencies {
     testImplementation 'com.google.truth:truth:0.42'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'com.google.guava:guava:27.0.1-jre'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 }
 
 apply from: 'publish.gradle'


### PR DESCRIPTION
Makes it possible to apply google-services plugin on top of `build.gradle` without warning. Also simplifies Android plugin lookup and adds functional tests.