### PR TITLE
Fixes `getMergeResourcesProvider` query name so plugin doesn't use deprecated APIs.

### DIFF
--- a/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesPlugin.groovy
+++ b/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesPlugin.groovy
@@ -196,7 +196,7 @@ class GoogleServicesPlugin implements Plugin<Project> {
     if (variant.respondsTo("registerGeneratedResFolders")) {
       task.ext.generatedResFolders = project.files(outputDir).builtBy(task)
       variant.registerGeneratedResFolders(task.generatedResFolders)
-      if (variant.respondsTo("mergeResourcesProvider")) {
+      if (variant.respondsTo("getMergeResourcesProvider")) {
         variant.mergeResourcesProvider.configure { dependsOn(task) }
       } else {
         //noinspection GrDeprecatedAPIUsage


### PR DESCRIPTION
I debugged the plugin to find that `variant.respondsTo("mergeResourcesProvider")` returns an empty collection, presumably because the actual method is called `getMergeResourcesProvider`, thought Groovy allows you to drop the `get`.

Fixes #65 