### PR TITLE
Fix handling of .pom files with multiple license declarations

### DIFF
--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
@@ -209,7 +209,7 @@ class LicensesTask extends DefaultTask {
             if (rootNode.licenses.size() == 0) continue
 
             String licenseKey = "${group}:${artifactName}"
-            if (rootNode.licenses.size() > 1) {
+            if (rootNode.licenses.license.size() > 1) {
                 rootNode.licenses.license.each { node ->
                     String nodeName = node.name
                     String nodeUrl = node.url

--- a/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/LicensesTaskTest.java
+++ b/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/LicensesTaskTest.java
@@ -158,6 +158,34 @@ public class LicensesTaskTest {
   }
 
   @Test
+  public void testAddLicensesFromPom_withMultiple() throws IOException {
+    File deps1 = new File("dependencies/groupA/deps1.txt");
+    String name1 = "deps1";
+    String group1 = "groupA";
+    licensesTask.addLicensesFromPom(deps1, name1, group1);
+
+    File deps2 = new File("dependencies/groupE/deps5.txt");
+    String name2 = "deps5";
+    String group2 = "groupE";
+    licensesTask.addLicensesFromPom(deps2, name2, group2);
+
+    String content = new String(Files.readAllBytes(licensesTask.licenses.toPath()), UTF_8);
+    String expected =
+        "http://www.opensource.org/licenses/mit-license.php"
+            + LINE_BREAK
+            + "http://www.opensource.org/licenses/mit-license.php"
+            + LINE_BREAK
+            + "https://www.apache.org/licenses/LICENSE-2.0"
+            + LINE_BREAK;
+
+    assertThat(licensesTask.licensesMap.size(), is(3));
+    assertTrue(licensesTask.licensesMap.containsKey("groupA:deps1"));
+    assertTrue(licensesTask.licensesMap.containsKey("groupE:deps5 MIT License"));
+    assertTrue(licensesTask.licensesMap.containsKey("groupE:deps5 Apache License 2.0"));
+    assertEquals(expected, content);
+  }
+
+  @Test
   public void testAddLicensesFromPom_withDuplicate() throws IOException {
     File deps1 = new File("dependencies/groupA/deps1.txt");
     String name1 = "deps1";

--- a/oss-licenses-plugin/src/test/resources/dependencies/groupE/deps5.pom
+++ b/oss-licenses-plugin/src/test/resources/dependencies/groupE/deps5.pom
@@ -1,0 +1,20 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>groupE</groupId>
+  <artifactId>groupE-deps5</artifactId>
+  <version>1</version>
+  <name>groupE deps5</name>
+  <description>groupE deps5</description>
+
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>http://www.opensource.org/licenses/mit-license.php</url>
+    </license>
+    <license>
+      <name>Apache License 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+    </license>
+  </licenses>
+</project>

--- a/oss-licenses-plugin/src/test/resources/dependencies/groupE/deps5.txt
+++ b/oss-licenses-plugin/src/test/resources/dependencies/groupE/deps5.txt
@@ -1,0 +1,1 @@
+Dependency 5


### PR DESCRIPTION
Fixes #6.

I've included a testcase that failed before the change and passes afterward. I don't really understand all the nuances of the test setup here so please let me know if this could be done better.