### PR TITLE
if a dependency has a range of valid library, skip the check

### DIFF
--- a/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/VersionEvaluation.kt
+++ b/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/VersionEvaluation.kt
@@ -11,19 +11,28 @@ interface VersionEvaluator {
  */
 object VersionEvaluators {
 
+  private fun containsVersionRange(version:String):Boolean{
+    return version.contains(',') ||
+           //open range
+           version.endsWith('[') ||
+           version.endsWith(')') ||
+           version.startsWith(']') ||
+           version.endsWith('(')
+  }
+
   fun getEvaluator(versionString: String, enableStrictMatching: Boolean): VersionEvaluator {
-    val hasVersionRange = versionString.indexOf(",") > 0 || versionString.indexOf(")") > 0 ||
-                                   versionString.indexOf("(") > 0
-    return if (versionString.startsWith("[") && versionString.endsWith("]")) {
-      ExactVersionEvaluator(versionString.substring(1, versionString.length - 1))
-    } else if (enableStrictMatching && !hasVersionRange) {
+    val hasVersionRange = containsVersionRange(versionString)
+    return if (hasVersionRange) {
+      //TODO: Support range version
+      AlwaysCompatibleEvaluator()
+    }else if (enableStrictMatching) {
       // TODO: Re-enable SemVer validator.
       // SemVerVersionEvaluator(versionString)
       AlwaysCompatibleEvaluator()
-    } else {
-      AlwaysCompatibleEvaluator()
+    }else{
+      val version = versionString.removePrefix("[").removeSuffix("]")
+      ExactVersionEvaluator(version)
     }
-
   }
 
   class AlwaysCompatibleEvaluator : VersionEvaluator {

--- a/strict-version-matcher-plugin/src/test/java/com/google/android/gms/dependencies/VersionRangeParser.kt
+++ b/strict-version-matcher-plugin/src/test/java/com/google/android/gms/dependencies/VersionRangeParser.kt
@@ -1,0 +1,45 @@
+package com.google.android.gms.dependencies
+
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class VersionRangeParser{
+
+  @Test
+  fun passIfCheckTheSameVersion(){
+    Assert.assertTrue(ART_A_100_TO_ART_B_100.isVersionCompatible ("1.0.0"))
+  }
+
+  @Test
+  fun closeRangeVersionAreNotSupportedAndAllTheVersionAreCompatible(){
+    val dep = createDependecyWithVersion("[1.0,10.0]")
+    Assert.assertTrue(dep.isVersionCompatible ("20.0"))
+  }
+
+  @Test
+  fun openRangeVersionAreNotSupportedAndAllTheVersionAreCompatible(){
+    val dep = createDependecyWithVersion("(1.0,10.0)")
+    Assert.assertTrue(dep.isVersionCompatible ("20.0"))
+  }
+
+  @Test
+  fun mixedRangeVersionAreNotSupportedAndAllTheVersionAreCompatible(){
+    val dep = arrayOf(
+        createDependecyWithVersion("[1.0,10.0)"),
+        createDependecyWithVersion("(1.0,10.0]"),
+        createDependecyWithVersion("[10.0,)"),
+        createDependecyWithVersion("]1.0,10.0]"),
+        createDependecyWithVersion("[1.0,10.0[")
+    )
+    dep.forEach {
+      Assert.assertTrue(it.isVersionCompatible("20.0"))
+    }
+  }
+
+  private fun createDependecyWithVersion(version:String):Dependency =
+    Dependency(ARTIFACT_A_100,Artifact("a","b"),version)
+
+}


### PR DESCRIPTION
Fix #30 

in the current code if the version is a range the version check is skipped only if the semantic version is enabled