### PR TITLE
Fix strict-version-matcher wrong VersionEvaluator returned from VersionEvaluators.getEvaluator

### DIFF
--- a/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/VersionEvaluation.kt
+++ b/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/VersionEvaluation.kt
@@ -14,7 +14,7 @@ object VersionEvaluators {
   fun getEvaluator(versionString: String, enableStrictMatching: Boolean): VersionEvaluator {
     val hasVersionRange = versionString.indexOf(",") > 0 || versionString.indexOf(")") > 0 ||
                                    versionString.indexOf("(") > 0
-    return if (versionString.startsWith("[") && versionString.endsWith("]")) {
+    return if (enableStrictMatching && versionString.startsWith("[") && versionString.endsWith("]")) {
       ExactVersionEvaluator(versionString.substring(1, versionString.length - 1))
     } else if (enableStrictMatching && !hasVersionRange) {
       // TODO: Re-enable SemVer validator.


### PR DESCRIPTION
The issue is that if a project contains dependencies with `[...]` and use **google-play-services** plugin then it fails to build because of the version check. 
As an example of such a dependency can be used `com.nimbusds:nimbus-jose-jwt:7.8`.
The result of the build will be following
```
In project 'app' a resolved Google Play services library dependency depends on another at an exact version (e.g. "[1.3.1
,2.3]", but isn't being resolved to that version. Behavior exhibited by the library will be unknown.

Dependency failing: com.nimbusds:nimbus-jose-jwt:7.8 -> net.minidev:json-smart@[1.3.1,2.3], but json-smart version was 2
.3.

The following dependencies are project dependencies that are direct or have transitive dependencies that lead to the art
ifact with the issue.
-- Project 'app' depends onto com.nimbusds:nimbus-jose-jwt@7.8
-- Project 'app' depends onto net.minidev:json-smart@{strictly 2.3}
-- Project 'app' depends onto com.nimbusds:nimbus-jose-jwt@{strictly 7.8}

For extended debugging info execute Gradle from the command line with ./gradlew --info :app:assembleDebug to see the dep
endency paths to the artifact. This error message came from the google-services Gradle plugin, report issues at https://
github.com/google/play-services-plugins and disable by adding "googleServices { disableVersionCheck = false }" to your b
uild.gradle file.
```
But project should be build normally cause this is not a google services dependency.
Project with illustrated issue can be found [here](https://github.com/ArtsemKurantsou/PlayServicesPluginTest).