### PR TITLE
Pom cache missing

### DIFF
--- a/oss-licenses-plugin/build.gradle
+++ b/oss-licenses-plugin/build.gradle
@@ -4,13 +4,13 @@ apply plugin: 'java'
 dependencies {
     implementation gradleApi()
     implementation localGroovy()
-    implementation 'com.android.tools.build:gradle:3.4.2'
+    implementation 'com.android.tools.build:gradle:3.5.1'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.23.4'
 }
 
 group = 'com.google.android.gms'
-version = '0.10.0'
+version = '0.11.0'
 
 apply plugin: 'maven'
 

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
@@ -18,13 +18,18 @@ package com.google.android.gms.oss.licenses.plugin
 
 import groovy.json.JsonSlurper
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.FileTree
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.result.ResolvedArtifactResult
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.maven.MavenModule
+import org.gradle.maven.MavenPomArtifact
+import org.slf4j.LoggerFactory
 
-import java.util.regex.Pattern
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 
@@ -44,7 +49,8 @@ class LicensesTask extends DefaultTask {
     private static final String FIREBASE_GROUP = "com.google.firebase"
     private static final String FAIL_READING_LICENSES_ERROR =
         "Failed to read license text."
-    private static final Pattern FILE_EXTENSION = ~/\.[^\.]+$/
+
+    private static final logger = LoggerFactory.getLogger(LicensesTask.class)
 
     protected int start = 0
     protected Set<String> googleServiceLicenses = []
@@ -79,7 +85,7 @@ class LicensesTask extends DefaultTask {
             if (isGoogleServices(group, name)) {
                 // Add license info for google-play-services itself
                 if (!name.endsWith(LICENSE_ARTIFACT_SURFIX)) {
-                    addLicensesFromPom(artifactLocation, name, group)
+                    addLicensesFromPom(group, name, version)
                 }
                 // Add transitive licenses info for google-play-services. For
                 // post-granular versions, this is located in the artifact
@@ -92,7 +98,7 @@ class LicensesTask extends DefaultTask {
                     addGooglePlayServiceLicenses(artifactLocation)
                 }
             } else {
-                addLicensesFromPom(artifactLocation, name, group)
+                addLicensesFromPom(group, name, version)
             }
         }
 
@@ -107,7 +113,7 @@ class LicensesTask extends DefaultTask {
 
     protected void initLicenseFile() {
         if (licenses == null) {
-            println("not defined licenses")
+            logger.error("License file is undefined")
         }
         licenses.newWriter().withWriter {w ->
             w << ''
@@ -194,32 +200,59 @@ class LicensesTask extends DefaultTask {
         }
     }
 
-    protected void addLicensesFromPom(File artifactFile, String artifactName,
-        String group) {
-        String pomFileName = artifactFile.getName().replaceFirst(FILE_EXTENSION,
-            ".pom")
+    protected void addLicensesFromPom(String group, String name, String version) {
+        def pomFile = resolvePomFileArtifact(group, name, version)
+        addLicensesFromPom(pomFile, group, name)
+    }
 
-        // Search for pom file. When the artifact is cached in gradle cache, the
-        // pom file will be stored in a hashed directory.
-        FileTree tree = project.fileTree(
-            dir: artifactFile.parentFile.parentFile,
-            include: ["**/${pomFileName}", pomFileName])
-        for (File pomFile : tree) {
-            def rootNode = new XmlSlurper().parse(pomFile)
-            if (rootNode.licenses.size() == 0) continue
-
-            String licenseKey = "${group}:${artifactName}"
-            if (rootNode.licenses.license.size() > 1) {
-                rootNode.licenses.license.each { node ->
-                    String nodeName = node.name
-                    String nodeUrl = node.url
-                    appendLicense("${licenseKey} ${nodeName}", nodeUrl.getBytes(UTF_8))
-                }
-            } else {
-                String nodeUrl = rootNode.licenses.license.url
-                appendLicense(licenseKey, nodeUrl.getBytes(UTF_8))
-            }
+    protected void addLicensesFromPom(File pomFile, String group, String name) {
+        if (pomFile == null || !pomFile.exists()) {
+            logger.error("POM file $pomFile does not exist.")
+            return
         }
+
+        def rootNode = new XmlSlurper().parse(pomFile)
+        if (rootNode.licenses.size() == 0) {
+            return
+        }
+
+        String licenseKey = "${group}:${name}"
+        if (rootNode.licenses.license.size() > 1) {
+            rootNode.licenses.license.each { node ->
+                String nodeName = node.name
+                String nodeUrl = node.url
+                appendLicense("${licenseKey} ${nodeName}", nodeUrl.getBytes(UTF_8))
+            }
+        } else {
+            String nodeUrl = rootNode.licenses.license.url
+            appendLicense(licenseKey, nodeUrl.getBytes(UTF_8))
+        }
+    }
+
+    protected File resolvePomFileArtifact(String group, String name, String version) {
+        def moduleComponentIdentifier =
+                createModuleComponentIdentifier(group, name, version)
+        logger.info("Resolving POM file for $moduleComponentIdentifier licenses.")
+        def components = getProject().getDependencies()
+                .createArtifactResolutionQuery()
+                .forComponents(moduleComponentIdentifier)
+                .withArtifacts(MavenModule.class, MavenPomArtifact.class)
+                .execute()
+        if (components.resolvedComponents.isEmpty()) {
+            logger.warn("$moduleComponentIdentifier has no POM file.")
+            return null
+        }
+
+        def artifacts = components.resolvedComponents[0].getArtifacts(MavenPomArtifact.class)
+        if (artifacts.isEmpty()) {
+            logger.error("$moduleComponentIdentifier empty POM artifact list.")
+            return null
+        }
+        if (!(artifacts[0] instanceof ResolvedArtifactResult)) {
+            logger.error("$moduleComponentIdentifier unexpected type ${artifacts[0].class}")
+            return null
+        }
+        return ((ResolvedArtifactResult) artifacts[0]).getFile()
     }
 
     protected void appendLicense(String key, byte[] content) {
@@ -243,4 +276,9 @@ class LicensesTask extends DefaultTask {
             licensesMetadata.append(LINE_SEPARATOR)
         }
     }
+
+    private static ModuleComponentIdentifier createModuleComponentIdentifier(String group, String name, String version) {
+        return new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, name), version)
+    }
+
 }

--- a/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/LicensesTaskTest.java
+++ b/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/LicensesTaskTest.java
@@ -121,10 +121,10 @@ public class LicensesTaskTest {
 
   @Test
   public void testAddLicensesFromPom() throws IOException {
-    File deps1 = new File("dependencies/groupA/deps1.txt");
+    File deps1 = getResourceFile("dependencies/groupA/deps1.pom");
     String name1 = "deps1";
     String group1 = "groupA";
-    licensesTask.addLicensesFromPom(deps1, name1, group1);
+    licensesTask.addLicensesFromPom(deps1, group1, name1);
 
     String content = new String(Files.readAllBytes(licensesTask.licenses.toPath()), UTF_8);
     String expected = "http://www.opensource.org/licenses/mit-license.php" + LINE_BREAK;
@@ -134,15 +134,15 @@ public class LicensesTaskTest {
 
   @Test
   public void testAddLicensesFromPom_withoutDuplicate() throws IOException {
-    File deps1 = new File("dependencies/groupA/deps1.txt");
+    File deps1 = getResourceFile("dependencies/groupA/deps1.pom");
     String name1 = "deps1";
     String group1 = "groupA";
-    licensesTask.addLicensesFromPom(deps1, name1, group1);
+    licensesTask.addLicensesFromPom(deps1, group1, name1);
 
-    File deps2 = new File("dependencies/groupB/deps2.txt");
+    File deps2 = getResourceFile("dependencies/groupB/bcd/deps2.pom");
     String name2 = "deps2";
     String group2 = "groupB";
-    licensesTask.addLicensesFromPom(deps2, name2, group2);
+    licensesTask.addLicensesFromPom(deps2, group2, name2);
 
     String content = new String(Files.readAllBytes(licensesTask.licenses.toPath()), UTF_8);
     String expected =
@@ -159,15 +159,15 @@ public class LicensesTaskTest {
 
   @Test
   public void testAddLicensesFromPom_withMultiple() throws IOException {
-    File deps1 = new File("dependencies/groupA/deps1.txt");
+    File deps1 = getResourceFile("dependencies/groupA/deps1.pom");
     String name1 = "deps1";
     String group1 = "groupA";
-    licensesTask.addLicensesFromPom(deps1, name1, group1);
+    licensesTask.addLicensesFromPom(deps1, group1, name1);
 
-    File deps2 = new File("dependencies/groupE/deps5.txt");
+    File deps2 = getResourceFile("dependencies/groupE/deps5.pom");
     String name2 = "deps5";
     String group2 = "groupE";
-    licensesTask.addLicensesFromPom(deps2, name2, group2);
+    licensesTask.addLicensesFromPom(deps2, group2, name2);
 
     String content = new String(Files.readAllBytes(licensesTask.licenses.toPath()), UTF_8);
     String expected =
@@ -187,15 +187,15 @@ public class LicensesTaskTest {
 
   @Test
   public void testAddLicensesFromPom_withDuplicate() throws IOException {
-    File deps1 = new File("dependencies/groupA/deps1.txt");
+    File deps1 = getResourceFile("dependencies/groupA/deps1.pom");
     String name1 = "deps1";
     String group1 = "groupA";
-    licensesTask.addLicensesFromPom(deps1, name1, group1);
+    licensesTask.addLicensesFromPom(deps1, group1, name1);
 
-    File deps2 = new File("dependencies/groupA/deps1.txt");
+    File deps2 = getResourceFile("dependencies/groupA/deps1.pom");
     String name2 = "deps1";
     String group2 = "groupA";
-    licensesTask.addLicensesFromPom(deps2, name2, group2);
+    licensesTask.addLicensesFromPom(deps2, group2, name2);
 
     String content = new String(Files.readAllBytes(licensesTask.licenses.toPath()), UTF_8);
     String expected = "http://www.opensource.org/licenses/mit-license.php" + LINE_BREAK;
@@ -203,6 +203,10 @@ public class LicensesTaskTest {
     assertThat(licensesTask.licensesMap.size(), is(1));
     assertTrue(licensesTask.licensesMap.containsKey("groupA:deps1"));
     assertEquals(expected, content);
+  }
+
+  private File getResourceFile(String resourcePath) {
+    return new File(getClass().getClassLoader().getResource(resourcePath).getFile());
   }
 
   @Test


### PR DESCRIPTION
As noticed in #99 some some libraries are missing license information. After looking into the issue we rely on .pom files being cached alongside library archive(.jar, .aar) files. Gradle caching has changed since the original implementation and now leaf dependencies that are not direct implementation dependencies are being omitted because the .pom file was not cached.

This PR switches from expecting .pom files to be cached along with other artifacts to explicitly ensuring the POM file is available using Gradle's Artifact Query API. This removes our reliance on Gradle's underlying cache implementation details.