### PR TITLE
Strict Version Matcher fix for non-google deps

### DIFF
--- a/google-services-plugin/build.gradle
+++ b/google-services-plugin/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 group = 'com.google.gms'
-version = '4.3.2'
+version = '4.3.3'
 project.ext.archivesBaseName = 'google-services'
 project.ext.pomDesc = 'Gradle plug-in to build Firebase applications.'
 
@@ -22,7 +22,7 @@ repositories {
 
 dependencies {
     implementation gradleApi()
-    implementation 'com.google.android.gms:strict-version-matcher-plugin:1.2.0'
+    implementation 'com.google.android.gms:strict-version-matcher-plugin:1.2.1'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.google.guava:guava:27.0.1-jre'
     testImplementation 'junit:junit:4.12'

--- a/strict-version-matcher-plugin/build.gradle
+++ b/strict-version-matcher-plugin/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
 project.ext.group = 'com.google.android.gms'
 project.ext.archivesBaseName = 'strict-version-matcher-plugin'
-project.ext.version = '1.2.0'
+project.ext.version = '1.2.1'
 project.ext.pomDesc = 'Gradle plug-in to enforce version ranges for Google Play services and Firebase dependencies.'
 
 apply plugin: 'kotlin'

--- a/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/DependencyAnalyzer.java
+++ b/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/DependencyAnalyzer.java
@@ -30,7 +30,7 @@ public class DependencyAnalyzer {
   private ArtifactDependencyManager dependencyManager = new ArtifactDependencyManager();
 
   /**
-   * Register a {Dependency}, only for google dependencies.
+   * Register a {Dependency}.
    */
   synchronized void registerDependency(@Nonnull Dependency dependency) {
     dependencyManager.addDependency(dependency);

--- a/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/DependencyAnalyzer.java
+++ b/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/DependencyAnalyzer.java
@@ -101,6 +101,6 @@ public class DependencyAnalyzer {
     }
   }
   private static boolean isGoogleDependency(Dependency dep) {
-    return GOOGLE_GROUP_IDS.contains(dep.getFromArtifactVersion().getGroupId());
+    return GOOGLE_GROUP_IDS.contains(dep.getToArtifact().getGroupId());
   }
 }

--- a/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/DependencyAnalyzer.java
+++ b/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/DependencyAnalyzer.java
@@ -7,9 +7,6 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Set;
-
-import com.google.common.collect.ImmutableSet; 
 
 /**
  * {Dependency} collector and analyzer for build artifacts.
@@ -28,9 +25,6 @@ import com.google.common.collect.ImmutableSet;
  * TODO: Support SemVer qualifiers.
  */
 public class DependencyAnalyzer {
-  private static final Set<String> GOOGLE_GROUP_IDS = ImmutableSet.of(
-      "com.google.android.gms",
-      "com.google.firebase");
   private Logger logger = LoggerFactory.getLogger(DependencyAnalyzer.class);
 
   private ArtifactDependencyManager dependencyManager = new ArtifactDependencyManager();
@@ -39,9 +33,6 @@ public class DependencyAnalyzer {
    * Register a {Dependency}, only for google dependencies.
    */
   synchronized void registerDependency(@Nonnull Dependency dependency) {
-    if (!isGoogleDependency(dependency)) {
-      return;
-    }
     dependencyManager.addDependency(dependency);
   }
 
@@ -99,8 +90,5 @@ public class DependencyAnalyzer {
         getNode(terminalPathList, new Node(n, dep), dep.getFromArtifactVersion());
       }
     }
-  }
-  private static boolean isGoogleDependency(Dependency dep) {
-    return GOOGLE_GROUP_IDS.contains(dep.getToArtifact().getGroupId());
   }
 }

--- a/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/DependencyAnalyzer.java
+++ b/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/DependencyAnalyzer.java
@@ -7,6 +7,9 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet; 
 
 /**
  * {Dependency} collector and analyzer for build artifacts.
@@ -25,14 +28,20 @@ import java.util.HashSet;
  * TODO: Support SemVer qualifiers.
  */
 public class DependencyAnalyzer {
+  private static final Set<String> GOOGLE_GROUP_IDS = ImmutableSet.of(
+      "com.google.android.gms",
+      "com.google.firebase");
   private Logger logger = LoggerFactory.getLogger(DependencyAnalyzer.class);
 
   private ArtifactDependencyManager dependencyManager = new ArtifactDependencyManager();
 
   /**
-   * Register a {Dependency}.
+   * Register a {Dependency}, only for google dependencies.
    */
   synchronized void registerDependency(@Nonnull Dependency dependency) {
+    if (!isGoogleDependency(dependency)) {
+      return;
+    }
     dependencyManager.addDependency(dependency);
   }
 
@@ -90,5 +99,8 @@ public class DependencyAnalyzer {
         getNode(terminalPathList, new Node(n, dep), dep.getFromArtifactVersion());
       }
     }
+  }
+  private static boolean isGoogleDependency(Dependency dep) {
+    return GOOGLE_GROUP_IDS.contains(dep.getFromArtifactVersion().getGroupId());
   }
 }

--- a/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/VersionEvaluation.kt
+++ b/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/VersionEvaluation.kt
@@ -14,7 +14,7 @@ object VersionEvaluators {
   fun getEvaluator(versionString: String, enableStrictMatching: Boolean): VersionEvaluator {
     val hasVersionRange = versionString.indexOf(",") > 0 || versionString.indexOf(")") > 0 ||
                                    versionString.indexOf("(") > 0
-    return if (versionString.startsWith("[") && versionString.endsWith("]")) {
+    return if (enableStrictMatching && versionString.startsWith("[") && versionString.endsWith("]")) {
       ExactVersionEvaluator(versionString.substring(1, versionString.length - 1))
     } else if (enableStrictMatching && !hasVersionRange) {
       // TODO: Re-enable SemVer validator.

--- a/strict-version-matcher-plugin/src/test/java/com/google/android/gms/dependencies/DependencyAnalyzerTest.java
+++ b/strict-version-matcher-plugin/src/test/java/com/google/android/gms/dependencies/DependencyAnalyzerTest.java
@@ -91,8 +91,8 @@ public class DependencyAnalyzerTest {
     }
 
     @Test
-    public void testNonGoogleDependencies_ShouldBeIgnored() {
-        ArtifactVersion fromVersion = ArtifactVersion.Companion.fromGradleRef("com.google.notfirebase:artA:1.0.0");
+    public void testNonGoogleToDependencies_ShouldBeIgnored() {
+        ArtifactVersion fromVersion = ArtifactVersion.Companion.fromGradleRef("com.google.firebase:artA:1.0.0");
         ArtifactVersion toVersion = ArtifactVersion.Companion.fromGradleRef("com.google.notfirebase:artB:1.0.0");
         Dependency dep = Dependency.Companion.fromArtifactVersions(fromVersion, toVersion);
         DependencyAnalyzer dependencyAnalyzer = new DependencyAnalyzer();
@@ -100,6 +100,19 @@ public class DependencyAnalyzerTest {
         Assert.assertEquals(
             "The dependency is ignored.", 
             0,
+            dependencyAnalyzer.getActiveDependencies(Lists.newArrayList(fromVersion, toVersion)).size());
+    }
+
+    @Test
+    public void testNonGoogleFromDependencies_ShouldNotBeIgnored() {
+        ArtifactVersion fromVersion = ArtifactVersion.Companion.fromGradleRef("com.google.notfirebase:artA:1.0.0");
+        ArtifactVersion toVersion = ArtifactVersion.Companion.fromGradleRef("com.google.firebase:artB:1.0.0");
+        Dependency dep = Dependency.Companion.fromArtifactVersions(fromVersion, toVersion);
+        DependencyAnalyzer dependencyAnalyzer = new DependencyAnalyzer();
+        dependencyAnalyzer.registerDependency(dep);
+        Assert.assertEquals(
+            "The dependency is not ignored.", 
+            1,
             dependencyAnalyzer.getActiveDependencies(Lists.newArrayList(fromVersion, toVersion)).size());
     }
 }

--- a/strict-version-matcher-plugin/src/test/java/com/google/android/gms/dependencies/DependencyAnalyzerTest.java
+++ b/strict-version-matcher-plugin/src/test/java/com/google/android/gms/dependencies/DependencyAnalyzerTest.java
@@ -89,30 +89,4 @@ public class DependencyAnalyzerTest {
                 ARTIFACT_A_100, ARTIFACT_B_100, ARTIFACT_C_200, ARTIFACT_D_100));
         Assert.assertEquals("Exactly 4 dependencies should be active.", 4, deps.size());
     }
-
-    @Test
-    public void testNonGoogleToDependencies_ShouldBeIgnored() {
-        ArtifactVersion fromVersion = ArtifactVersion.Companion.fromGradleRef("com.google.firebase:artA:1.0.0");
-        ArtifactVersion toVersion = ArtifactVersion.Companion.fromGradleRef("com.google.notfirebase:artB:1.0.0");
-        Dependency dep = Dependency.Companion.fromArtifactVersions(fromVersion, toVersion);
-        DependencyAnalyzer dependencyAnalyzer = new DependencyAnalyzer();
-        dependencyAnalyzer.registerDependency(dep);
-        Assert.assertEquals(
-            "The dependency is ignored.", 
-            0,
-            dependencyAnalyzer.getActiveDependencies(Lists.newArrayList(fromVersion, toVersion)).size());
-    }
-
-    @Test
-    public void testNonGoogleFromDependencies_ShouldNotBeIgnored() {
-        ArtifactVersion fromVersion = ArtifactVersion.Companion.fromGradleRef("com.google.notfirebase:artA:1.0.0");
-        ArtifactVersion toVersion = ArtifactVersion.Companion.fromGradleRef("com.google.firebase:artB:1.0.0");
-        Dependency dep = Dependency.Companion.fromArtifactVersions(fromVersion, toVersion);
-        DependencyAnalyzer dependencyAnalyzer = new DependencyAnalyzer();
-        dependencyAnalyzer.registerDependency(dep);
-        Assert.assertEquals(
-            "The dependency is not ignored.", 
-            1,
-            dependencyAnalyzer.getActiveDependencies(Lists.newArrayList(fromVersion, toVersion)).size());
-    }
 }

--- a/strict-version-matcher-plugin/src/test/java/com/google/android/gms/dependencies/DependencyAnalyzerTest.java
+++ b/strict-version-matcher-plugin/src/test/java/com/google/android/gms/dependencies/DependencyAnalyzerTest.java
@@ -89,4 +89,17 @@ public class DependencyAnalyzerTest {
                 ARTIFACT_A_100, ARTIFACT_B_100, ARTIFACT_C_200, ARTIFACT_D_100));
         Assert.assertEquals("Exactly 4 dependencies should be active.", 4, deps.size());
     }
+
+    @Test
+    public void testNonGoogleDependencies_ShouldBeIgnored() {
+        ArtifactVersion fromVersion = ArtifactVersion.Companion.fromGradleRef("com.google.notfirebase:artA:1.0.0");
+        ArtifactVersion toVersion = ArtifactVersion.Companion.fromGradleRef("com.google.notfirebase:artB:1.0.0");
+        Dependency dep = Dependency.Companion.fromArtifactVersions(fromVersion, toVersion);
+        DependencyAnalyzer dependencyAnalyzer = new DependencyAnalyzer();
+        dependencyAnalyzer.registerDependency(dep);
+        Assert.assertEquals(
+            "The dependency is ignored.", 
+            0,
+            dependencyAnalyzer.getActiveDependencies(Lists.newArrayList(fromVersion, toVersion)).size());
+    }
 }

--- a/strict-version-matcher-plugin/src/test/java/com/google/android/gms/dependencies/TestUtil.kt
+++ b/strict-version-matcher-plugin/src/test/java/com/google/android/gms/dependencies/TestUtil.kt
@@ -2,15 +2,15 @@ package com.google.android.gms.dependencies
 
 // These are constants used to refer to artifacts and constants across all of the test classes to increase readability.
 
-@JvmField val ARTIFACT_A_100 = ArtifactVersion.fromGradleRef("c.g.a:artA:1.0.0")
-@JvmField val ARTIFACT_A_200 = ArtifactVersion.fromGradleRef("c.g.a:artA:2.0.0")
-@JvmField val ARTIFACT_B_100 = ArtifactVersion.fromGradleRef("c.g.a:artB:1.0.0")
-@JvmField val ARTIFACT_B_200 = ArtifactVersion.fromGradleRef("c.g.a:artB:2.0.0")
-@JvmField val ARTIFACT_B_300 = ArtifactVersion.fromGradleRef("c.g.a:artB:3.0.0")
-@JvmField val ARTIFACT_C_100 = ArtifactVersion.fromGradleRef("c.g.b:artC:1.0.0")
-@JvmField val ARTIFACT_C_200 = ArtifactVersion.fromGradleRef("c.g.b:artC:2.0.0")
-@JvmField val ARTIFACT_D_100 = ArtifactVersion.fromGradleRef("c.g.b:artD:1.0.0")
-@JvmField val ARTIFACT_D_200 = ArtifactVersion.fromGradleRef("c.g.b:artD:2.0.0")
+@JvmField val ARTIFACT_A_100 = ArtifactVersion.fromGradleRef("com.google.firebase:artA:1.0.0")
+@JvmField val ARTIFACT_A_200 = ArtifactVersion.fromGradleRef("com.google.firebase:artA:2.0.0")
+@JvmField val ARTIFACT_B_100 = ArtifactVersion.fromGradleRef("com.google.firebase:artB:1.0.0")
+@JvmField val ARTIFACT_B_200 = ArtifactVersion.fromGradleRef("com.google.firebase:artB:2.0.0")
+@JvmField val ARTIFACT_B_300 = ArtifactVersion.fromGradleRef("com.google.firebase:artB:3.0.0")
+@JvmField val ARTIFACT_C_100 = ArtifactVersion.fromGradleRef("com.google.android.gms:artC:1.0.0")
+@JvmField val ARTIFACT_C_200 = ArtifactVersion.fromGradleRef("com.google.android.gms:artC:2.0.0")
+@JvmField val ARTIFACT_D_100 = ArtifactVersion.fromGradleRef("com.google.android.gms:artD:1.0.0")
+@JvmField val ARTIFACT_D_200 = ArtifactVersion.fromGradleRef("com.google.android.gms:artD:2.0.0")
 
 @JvmField val ART_A_100_TO_ART_B_100 = Dependency.fromArtifactVersions(ARTIFACT_A_100, ARTIFACT_B_100)
 @JvmField val ART_A_200_TO_ART_B_200 = Dependency.fromArtifactVersions(ARTIFACT_A_200, ARTIFACT_B_200)

--- a/strict-version-matcher-plugin/src/test/java/com/google/android/gms/dependencies/VersionEvaluationTest.java
+++ b/strict-version-matcher-plugin/src/test/java/com/google/android/gms/dependencies/VersionEvaluationTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gms.dependencies;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class VersionEvaluationTest {
+	private static final ArtifactVersion NON_GOOGLE_ARTIFACT = ArtifactVersion.Companion.fromGradleRef("com.notgoogle:randomlib:1.0.0");
+	private static final ArtifactVersion NON_GOOGLE_ARTIFACT_HARD_DEP = ArtifactVersion.Companion.fromGradleRef("com.notgoogle:randomlib:[1.0.0]");
+	private static final ArtifactVersion GOOGLE_ARTIFACT = ArtifactVersion.Companion.fromGradleRef("com.google.firebase:randomlib:1.0.0");
+	private static final ArtifactVersion GOOGLE_ARTIFACT_HARD_DEP = ArtifactVersion.Companion.fromGradleRef("com.google.firebase:randomlib:[1.0.0]");
+	private static final Dependency HARD_DEP_ON_GOOGLE = Dependency.Companion.fromArtifactVersions(NON_GOOGLE_ARTIFACT, GOOGLE_ARTIFACT_HARD_DEP);
+	private static final Dependency SOFT_DEP_ON_GOOGLE = Dependency.Companion.fromArtifactVersions(NON_GOOGLE_ARTIFACT, GOOGLE_ARTIFACT);
+	private static final Dependency SOFT_NON_GOOGLE_DEP = Dependency.Companion.fromArtifactVersions(NON_GOOGLE_ARTIFACT, NON_GOOGLE_ARTIFACT);
+	private static final Dependency HARD_NON_GOOGLE_DEP = Dependency.Companion.fromArtifactVersions(NON_GOOGLE_ARTIFACT, NON_GOOGLE_ARTIFACT_HARD_DEP);
+
+
+  @Test
+  public void hardDepOnGoogleLibraryRequiresExactVersion(){
+    Assert.assertFalse(HARD_DEP_ON_GOOGLE.isVersionCompatible ("2.0.0"));
+    Assert.assertTrue(HARD_DEP_ON_GOOGLE.isVersionCompatible ("1.0.0"));
+  }
+
+  @Test
+  public void softDepOnGoogleLibraryAcceptsAny(){
+  	Assert.assertTrue(SOFT_DEP_ON_GOOGLE.isVersionCompatible ("1.0.0"));
+    Assert.assertTrue(SOFT_DEP_ON_GOOGLE.isVersionCompatible ("2.0.0"));
+  }
+
+  @Test
+  public void softDepOnNonGoogleLibraryAcceptsAny(){
+    Assert.assertTrue(SOFT_NON_GOOGLE_DEP.isVersionCompatible ("2.0.0"));
+    Assert.assertTrue(SOFT_NON_GOOGLE_DEP.isVersionCompatible ("1.0.0"));
+  }
+
+  @Test
+  public void hardDepOnNonGoogleLibraryAcceptsAny(){
+    Assert.assertTrue(HARD_NON_GOOGLE_DEP.isVersionCompatible ("2.0.0"));
+    Assert.assertTrue(HARD_NON_GOOGLE_DEP.isVersionCompatible ("1.0.0"));
+  }
+}

--- a/strict-version-matcher-plugin/src/test/java/com/google/android/gms/dependencies/VersionEvaluationTest.java
+++ b/strict-version-matcher-plugin/src/test/java/com/google/android/gms/dependencies/VersionEvaluationTest.java
@@ -23,14 +23,14 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class VersionEvaluationTest {
-	private static final ArtifactVersion NON_GOOGLE_ARTIFACT = ArtifactVersion.Companion.fromGradleRef("com.notgoogle:randomlib:1.0.0");
-	private static final ArtifactVersion NON_GOOGLE_ARTIFACT_HARD_DEP = ArtifactVersion.Companion.fromGradleRef("com.notgoogle:randomlib:[1.0.0]");
-	private static final ArtifactVersion GOOGLE_ARTIFACT = ArtifactVersion.Companion.fromGradleRef("com.google.firebase:randomlib:1.0.0");
-	private static final ArtifactVersion GOOGLE_ARTIFACT_HARD_DEP = ArtifactVersion.Companion.fromGradleRef("com.google.firebase:randomlib:[1.0.0]");
-	private static final Dependency HARD_DEP_ON_GOOGLE = Dependency.Companion.fromArtifactVersions(NON_GOOGLE_ARTIFACT, GOOGLE_ARTIFACT_HARD_DEP);
-	private static final Dependency SOFT_DEP_ON_GOOGLE = Dependency.Companion.fromArtifactVersions(NON_GOOGLE_ARTIFACT, GOOGLE_ARTIFACT);
-	private static final Dependency SOFT_NON_GOOGLE_DEP = Dependency.Companion.fromArtifactVersions(NON_GOOGLE_ARTIFACT, NON_GOOGLE_ARTIFACT);
-	private static final Dependency HARD_NON_GOOGLE_DEP = Dependency.Companion.fromArtifactVersions(NON_GOOGLE_ARTIFACT, NON_GOOGLE_ARTIFACT_HARD_DEP);
+  private static final ArtifactVersion NON_GOOGLE_ARTIFACT = ArtifactVersion.Companion.fromGradleRef("com.notgoogle:randomlib:1.0.0");
+  private static final ArtifactVersion NON_GOOGLE_ARTIFACT_HARD_DEP = ArtifactVersion.Companion.fromGradleRef("com.notgoogle:randomlib:[1.0.0]");
+  private static final ArtifactVersion GOOGLE_ARTIFACT = ArtifactVersion.Companion.fromGradleRef("com.google.firebase:randomlib:1.0.0");
+  private static final ArtifactVersion GOOGLE_ARTIFACT_HARD_DEP = ArtifactVersion.Companion.fromGradleRef("com.google.firebase:randomlib:[1.0.0]");
+  private static final Dependency HARD_DEP_ON_GOOGLE = Dependency.Companion.fromArtifactVersions(NON_GOOGLE_ARTIFACT, GOOGLE_ARTIFACT_HARD_DEP);
+  private static final Dependency SOFT_DEP_ON_GOOGLE = Dependency.Companion.fromArtifactVersions(NON_GOOGLE_ARTIFACT, GOOGLE_ARTIFACT);
+  private static final Dependency SOFT_NON_GOOGLE_DEP = Dependency.Companion.fromArtifactVersions(NON_GOOGLE_ARTIFACT, NON_GOOGLE_ARTIFACT);
+  private static final Dependency HARD_NON_GOOGLE_DEP = Dependency.Companion.fromArtifactVersions(NON_GOOGLE_ARTIFACT, NON_GOOGLE_ARTIFACT_HARD_DEP);
 
 
   @Test
@@ -41,7 +41,7 @@ public class VersionEvaluationTest {
 
   @Test
   public void softDepOnGoogleLibraryAcceptsAny(){
-  	Assert.assertTrue(SOFT_DEP_ON_GOOGLE.isVersionCompatible ("1.0.0"));
+    Assert.assertTrue(SOFT_DEP_ON_GOOGLE.isVersionCompatible ("1.0.0"));
     Assert.assertTrue(SOFT_DEP_ON_GOOGLE.isVersionCompatible ("2.0.0"));
   }
 


### PR DESCRIPTION
Strict version matcher should ignore non-google dependencies. 