### PR TITLE
Update GoogleServicesPlugin.groovy

### DIFF
--- a/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesPlugin.groovy
+++ b/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesPlugin.groovy
@@ -71,7 +71,7 @@ class GoogleServicesPlugin implements Plugin<Project> {
         new DependencyInspector(globalDependencies, project.getName(),
             "This error message came from the google-services Gradle plugin, report" +
                 " issues at https://github.com/google/play-services-plugins and disable by " +
-                "adding \"googleServices { disableVersionCheck = false }\" to your build.gradle file."));
+                "adding \"googleServices { disableVersionCheck = true }\" to your build.gradle file."));
     }
     for (PluginType pluginType : PluginType.values()) {
       for (String plugin : pluginType.plugins()) {


### PR DESCRIPTION
The error message on version check was prompting to use `disableVersionCheck` with `false` as its value. This won't actually disable the version check as the name of the parameter suggests.