### PR TITLE
Downgrade progress message from warning to info level

### DIFF
--- a/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesTask.java
+++ b/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesTask.java
@@ -152,7 +152,7 @@ public class GoogleServicesTask extends DefaultTask {
                       packageNameXOR1, packageNameXOR2));
     }
 
-    getProject().getLogger().warn("Parsing json file: " + quickstartFile.getPath());
+    getProject().getLogger().info("Parsing json file: " + quickstartFile.getPath());
 
     // delete content of outputdir.
     deleteFolder(intermediateDir);


### PR DESCRIPTION
I propose dropping the "level" of the "Parsing json file ..." progress/status message from a _warning_ message to an _info_ message. Any output from a Gradle task causes the task line, the message, and a blank line to be added to the output; whereas tasks with no output are "wiped" or overwritten. This "noise" in the output competes with real warnings, and other messages that we shouldn't ignore. As this message carries no corrective action to be taken, I don't believe that a "warning" is appropriate.