### PR TITLE
oss-licenses-plugin: Fix ambiguous method overloading

### DIFF
--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
@@ -202,7 +202,7 @@ class LicensesTask extends DefaultTask {
 
     protected void addLicensesFromPom(String group, String name, String version) {
         def pomFile = resolvePomFileArtifact(group, name, version)
-        addLicensesFromPom(pomFile, group, name)
+        addLicensesFromPom((File) pomFile, group, name)
     }
 
     protected void addLicensesFromPom(File pomFile, String group, String name) {


### PR DESCRIPTION
Fix #120 