### PR TITLE
Missing dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+repo/

--- a/oss-licenses-plugin/build.gradle
+++ b/oss-licenses-plugin/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 }
 
 group = 'com.google.android.gms'
-version = '0.10.1'
+version = '0.10.2'
 
 apply plugin: 'maven'
 

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyTask.groovy
@@ -47,8 +47,8 @@ class DependencyTask extends DefaultTask {
                                                      "androidTestCompile"]
 
     private static final Set<String> PACKAGED_DEPENDENCIES_PREFIXES = ["compile",
-                                                            "implementation",
-                                                            "api"]
+                                                                       "implementation",
+                                                                       "api"]
 
     @Input
     public ConfigurationContainer configurations
@@ -134,7 +134,7 @@ class DependencyTask extends DefaultTask {
      */
     protected boolean canBeResolved(Configuration configuration) {
         return configuration.metaClass.respondsTo(configuration,
-                "isCanBeResolved")? configuration.isCanBeResolved() : true
+                "isCanBeResolved") ? configuration.isCanBeResolved() : true
     }
 
     /**
@@ -147,7 +147,7 @@ class DependencyTask extends DefaultTask {
     protected boolean isTest(Configuration configuration) {
         boolean isTestConfiguration = (
                 configuration.name.startsWith(TEST_PREFIX) ||
-                configuration.name.startsWith(ANDROID_TEST_PREFIX))
+                        configuration.name.startsWith(ANDROID_TEST_PREFIX))
         configuration.hierarchy.each {
             isTestConfiguration |= TEST_COMPILE.contains(it.name)
         }
@@ -165,7 +165,7 @@ class DependencyTask extends DefaultTask {
         }
         configuration.hierarchy.each {
             String configurationHierarchyName = it.name
-            isPackagedDependency |=  PACKAGED_DEPENDENCIES_PREFIXES.any {
+            isPackagedDependency |= PACKAGED_DEPENDENCIES_PREFIXES.any {
                 configurationHierarchyName.startsWith(it)
             }
         }
@@ -179,6 +179,7 @@ class DependencyTask extends DefaultTask {
          * skip the configurations that, cannot be resolved in
          * newer version of gradle api, are tests, or are not packaged dependencies.
          */
+
         if (!canBeResolved(configuration)
                 || isTest(configuration)
                 || !isPackagedDependency(configuration)) {

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
@@ -207,7 +207,7 @@ class LicensesTask extends DefaultTask {
 
     protected void addLicensesFromPom(File pomFile, String group, String name) {
         if (pomFile == null || !pomFile.exists()) {
-            logger.error("POM file $pomFile does not exist.")
+            logger.error("POM file $pomFile for $group:$name does not exist.")
             return
         }
 

--- a/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/DependencyTaskTest.java
+++ b/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/DependencyTaskTest.java
@@ -22,21 +22,26 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.LenientConfiguration;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
+import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.testfixtures.ProjectBuilder;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -109,7 +114,13 @@ public class DependencyTaskTest {
 
   @Test
   public void testGetResolvedArtifacts_cannotResolve() {
+    Set<ResolvedArtifact> artifactSet = prepareArtifactSet(2);
+    ResolvedConfiguration resolvedConfiguration = mockResolvedConfiguration(artifactSet);
+
     Configuration configuration = mock(Configuration.class);
+    when(configuration.getName()).thenReturn("implementation");
+    when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
+
     when(configuration.isCanBeResolved()).thenReturn(false);
 
     assertThat(dependencyTask.getResolvedArtifacts(configuration), is(nullValue()));
@@ -117,74 +128,78 @@ public class DependencyTaskTest {
 
   @Test
   public void testGetResolvedArtifacts_isTest() {
+    Set<ResolvedArtifact> artifactSet = prepareArtifactSet(2);
+    ResolvedConfiguration resolvedConfiguration = mockResolvedConfiguration(artifactSet);
+
     Configuration configuration = mock(Configuration.class);
-    when(configuration.getName()).thenReturn("testCompile");
     when(configuration.isCanBeResolved()).thenReturn(true);
+    when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
+
+    when(configuration.getName()).thenReturn("testCompile");
 
     assertThat(dependencyTask.getResolvedArtifacts(configuration), is(nullValue()));
   }
 
   @Test
   public void testGetResolvedArtifacts_isNotPackaged() {
-    Set<ResolvedArtifact> artifactSet = (Set<ResolvedArtifact>) mock(Set.class);
-    ResolvedConfiguration resolvedConfiguration = mock(ResolvedConfiguration.class);
-    when(resolvedConfiguration.getResolvedArtifacts()).thenReturn(artifactSet);
+    Set<ResolvedArtifact> artifactSet = prepareArtifactSet(2);
+    ResolvedConfiguration resolvedConfiguration = mockResolvedConfiguration(artifactSet);
 
     Configuration configuration = mock(Configuration.class);
-    when(configuration.getName()).thenReturn("annotationProcessor");
     when(configuration.isCanBeResolved()).thenReturn(true);
     when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
+
+    when(configuration.getName()).thenReturn("random");
 
     assertThat(dependencyTask.getResolvedArtifacts(configuration), is(nullValue()));
   }
 
   @Test
   public void testGetResolvedArtifacts_isPackagedApi() {
-    Set<ResolvedArtifact> artifactSet = (Set<ResolvedArtifact>) mock(Set.class);
-    ResolvedConfiguration resolvedConfiguration = mock(ResolvedConfiguration.class);
-    when(resolvedConfiguration.getResolvedArtifacts()).thenReturn(artifactSet);
+    Set<ResolvedArtifact> artifactSet = prepareArtifactSet(2);
+    ResolvedConfiguration resolvedConfiguration = mockResolvedConfiguration(artifactSet);
 
     Configuration configuration = mock(Configuration.class);
-    when(configuration.getName()).thenReturn("api");
     when(configuration.isCanBeResolved()).thenReturn(true);
     when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
+
+    when(configuration.getName()).thenReturn("api");
 
     assertThat(dependencyTask.getResolvedArtifacts(configuration), is(artifactSet));
   }
 
   @Test
   public void testGetResolvedArtifacts_isPackagedImplementation() {
-    Set<ResolvedArtifact> artifactSet = (Set<ResolvedArtifact>) mock(Set.class);
-    ResolvedConfiguration resolvedConfiguration = mock(ResolvedConfiguration.class);
-    when(resolvedConfiguration.getResolvedArtifacts()).thenReturn(artifactSet);
+    Set<ResolvedArtifact> artifactSet = prepareArtifactSet(2);
+    ResolvedConfiguration resolvedConfiguration = mockResolvedConfiguration(artifactSet);
 
     Configuration configuration = mock(Configuration.class);
-    when(configuration.getName()).thenReturn("implementation");
     when(configuration.isCanBeResolved()).thenReturn(true);
     when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
+
+    when(configuration.getName()).thenReturn("implementation");
 
     assertThat(dependencyTask.getResolvedArtifacts(configuration), is(artifactSet));
   }
 
   @Test
   public void testGetResolvedArtifacts_isPackagedCompile() {
-    Set<ResolvedArtifact> artifactSet = (Set<ResolvedArtifact>) mock(Set.class);
-    ResolvedConfiguration resolvedConfiguration = mock(ResolvedConfiguration.class);
-    when(resolvedConfiguration.getResolvedArtifacts()).thenReturn(artifactSet);
+    Set<ResolvedArtifact> artifactSet = prepareArtifactSet(2);
+    ResolvedConfiguration resolvedConfiguration = mockResolvedConfiguration(artifactSet);
 
     Configuration configuration = mock(Configuration.class);
-    when(configuration.getName()).thenReturn("compile");
     when(configuration.isCanBeResolved()).thenReturn(true);
     when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
+
+    when(configuration.getName()).thenReturn("compile");
 
     assertThat(dependencyTask.getResolvedArtifacts(configuration), is(artifactSet));
   }
 
   @Test
-  public void testGetResolvedArtifacts_isPackagedInHierachy() {
-    Set<ResolvedArtifact> artifactSet = (Set<ResolvedArtifact>) mock(Set.class);
-    ResolvedConfiguration resolvedConfiguration = mock(ResolvedConfiguration.class);
-    when(resolvedConfiguration.getResolvedArtifacts()).thenReturn(artifactSet);
+  public void testGetResolvedArtifacts_isPackagedInHierarchy() {
+    Set<ResolvedArtifact> artifactSet = prepareArtifactSet(2);
+    ResolvedConfiguration resolvedConfiguration = mockResolvedConfiguration(artifactSet);
 
     Configuration configuration = mock(Configuration.class);
     when(configuration.getName()).thenReturn("random");
@@ -200,11 +215,10 @@ public class DependencyTaskTest {
     assertThat(dependencyTask.getResolvedArtifacts(configuration), is(artifactSet));
   }
 
-
   @Test
   public void testGetResolvedArtifacts_ResolveException() {
     ResolvedConfiguration resolvedConfiguration = mock(ResolvedConfiguration.class);
-    when(resolvedConfiguration.getResolvedArtifacts()).thenThrow(ResolveException.class);
+    when(resolvedConfiguration.getLenientConfiguration()).thenThrow(ResolveException.class);
 
     Configuration configuration = mock(Configuration.class);
     when(configuration.getName()).thenReturn("compile");
@@ -216,9 +230,8 @@ public class DependencyTaskTest {
 
   @Test
   public void testGetResolvedArtifacts_returnArtifact() {
-    Set<ResolvedArtifact> artifactSet = (Set<ResolvedArtifact>) mock(Set.class);
-    ResolvedConfiguration resolvedConfiguration = mock(ResolvedConfiguration.class);
-    when(resolvedConfiguration.getResolvedArtifacts()).thenReturn(artifactSet);
+    Set<ResolvedArtifact> artifactSet = prepareArtifactSet(2);
+    ResolvedConfiguration resolvedConfiguration = mockResolvedConfiguration(artifactSet);
 
     Configuration configuration = mock(Configuration.class);
     when(configuration.getName()).thenReturn("compile");
@@ -229,15 +242,62 @@ public class DependencyTaskTest {
   }
 
   @Test
-  public void testAddArtifacts() {
-    ResolvedConfiguration resolvedConfiguration = spy(ResolvedConfiguration.class);
-    Set<ResolvedArtifact> artifacts = preppareArtifactSet(3);
-    when(resolvedConfiguration.getResolvedArtifacts()).thenReturn(artifacts);
+  public void testGetResolvedArtifacts_libraryProject_returnsArtifacts() {
+    ResolvedDependency libraryResolvedDependency = mock(ResolvedDependency.class);
+    when(libraryResolvedDependency.getModuleVersion())
+            .thenReturn(DependencyTask.LOCAL_LIBRARY_VERSION);
+    ResolvedDependency libraryChildResolvedDependency = mock(ResolvedDependency.class);
+    Set<ResolvedArtifact> libraryChildArtifactSet =
+            prepareArtifactSet(/* start= */ 0, /* count= */ 2);
+    when(libraryChildResolvedDependency.getAllModuleArtifacts())
+            .thenReturn(libraryChildArtifactSet);
+    when(libraryResolvedDependency.getChildren())
+            .thenReturn(Collections.singleton(libraryChildResolvedDependency));
+
+    Set<ResolvedArtifact> appArtifactSet = prepareArtifactSet(/* start= */ 2, /* count= */ 2);
+    ResolvedDependency appResolvedDependency = mock(ResolvedDependency.class);
+    when(appResolvedDependency.getAllModuleArtifacts()).thenReturn(appArtifactSet);
+
+    Set<ResolvedDependency> resolvedDependencySet = new HashSet<>(
+            Arrays.asList(libraryResolvedDependency, appResolvedDependency));
+    ResolvedConfiguration resolvedConfiguration = mockResolvedConfigurationFromDependencySet(
+            resolvedDependencySet);
 
     Configuration configuration = mock(Configuration.class);
-    when(configuration.isCanBeResolved()).thenReturn(true);
     when(configuration.getName()).thenReturn("compile");
+    when(configuration.isCanBeResolved()).thenReturn(true);
     when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
+
+    Set<ResolvedArtifact> artifactSuperSet = new HashSet<>();
+    artifactSuperSet.addAll(appArtifactSet);
+    artifactSuperSet.addAll(libraryChildArtifactSet);
+    assertThat(dependencyTask.getResolvedArtifacts(configuration), is(artifactSuperSet));
+    // Calling getAllModuleArtifacts on a library will cause an exception.
+    verify(libraryResolvedDependency, never()).getAllModuleArtifacts();
+  }
+
+  @NotNull
+  private ResolvedConfiguration mockResolvedConfiguration(Set<ResolvedArtifact> artifactSet) {
+    ResolvedDependency resolvedDependency = mock(ResolvedDependency.class);
+    when(resolvedDependency.getAllModuleArtifacts()).thenReturn(artifactSet);
+    Set<ResolvedDependency> resolvedDependencySet = Collections.singleton(resolvedDependency);
+    return mockResolvedConfigurationFromDependencySet(resolvedDependencySet);
+  }
+
+  @NotNull
+  private ResolvedConfiguration mockResolvedConfigurationFromDependencySet(
+          Set<ResolvedDependency> resolvedDependencySet) {
+
+    LenientConfiguration lenientConfiguration = mock(LenientConfiguration.class);
+    when(lenientConfiguration.getFirstLevelModuleDependencies()).thenReturn(resolvedDependencySet);
+    ResolvedConfiguration resolvedConfiguration = mock(ResolvedConfiguration.class);
+    when(resolvedConfiguration.getLenientConfiguration()).thenReturn(lenientConfiguration);
+    return resolvedConfiguration;
+  }
+
+  @Test
+  public void testAddArtifacts() {
+    Set<ResolvedArtifact> artifacts = prepareArtifactSet(3);
 
     dependencyTask.addArtifacts(artifacts);
     assertThat(dependencyTask.artifactInfos.size(), is(3));
@@ -245,14 +305,7 @@ public class DependencyTaskTest {
 
   @Test
   public void testAddArtifacts_willNotAddDuplicate() {
-    ResolvedConfiguration resolvedConfiguration = spy(ResolvedConfiguration.class);
-    Set<ResolvedArtifact> artifacts = preppareArtifactSet(2);
-    when(resolvedConfiguration.getResolvedArtifacts()).thenReturn(artifacts);
-
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.isCanBeResolved()).thenReturn(true);
-    when(configuration.getName()).thenReturn("compile");
-    when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
+    Set<ResolvedArtifact> artifacts = prepareArtifactSet(2);
 
     String[] keySets = new String[] {"location1", "location2"};
     dependencyTask.artifactSet = new HashSet<>(Arrays.asList(keySets));
@@ -316,13 +369,17 @@ public class DependencyTaskTest {
     assertTrue(dependencyTask.isTest(configuration));
   }
 
-  private Set<ResolvedArtifact> preppareArtifactSet(int count) {
+  private Set<ResolvedArtifact> prepareArtifactSet(int count) {
+    return prepareArtifactSet(0, count);
+  }
+
+  private Set<ResolvedArtifact> prepareArtifactSet(int start, int count) {
     Set<ResolvedArtifact> artifacts = new HashSet<>();
     String namePrefix = "artifact";
     String groupPrefix = "group";
     String locationPrefix = "location";
     String versionPostfix = ".0";
-    for (int i = 0; i < count; i++) {
+    for (int i = start; i < start + count; i++) {
       String index = String.valueOf(i);
       artifacts.add(
           prepareArtifact(


### PR DESCRIPTION
Fixes #119 

When attempting to call getResolvedArtifacts() on a top level ResolvedConfiguration for an application project that also has library projects an AmbiguousVariantSelectionException will throw. Gradle cannot determine which variant of the library project it should evaluate for artifacts. None of the library project variants lead to artifacts supported by this tool.

This change avoids that by stepping over the library project itself and recursively walking the library project's dependencies. If the library project depends on other library projects, they are avoided in the same way. Once a direct, non-library-project dependency is reached, getAllModuleArtifacts() returns the self-inclusive artifact tree stemming from it.

The result is the set of transitive external dependencies of the application and its library projects.

This also includes separate commits to bump the version and ignore the generated repo folder, fix a logging gap, and enable the use of automatic formatting.