### PR TITLE
Use separate buildType and productFlavors for determining the json locations

### DIFF
--- a/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesPlugin.groovy
+++ b/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesPlugin.groovy
@@ -67,8 +67,8 @@ class GoogleServicesPlugin implements Plugin<Project> {
         return
       }
       DependencyAnalyzer globalDependencies = new DependencyAnalyzer()
-      project.getGradle().addListener(
-        new DependencyInspector(globalDependencies, project.getName(),
+      project.gradle.addListener(
+        new DependencyInspector(globalDependencies, project.name,
             "This error message came from the google-services Gradle plugin, report" +
                 " issues at https://github.com/google/play-services-plugins and disable by " +
                 "adding \"googleServices { disableVersionCheck = true }\" to your build.gradle file."));
@@ -87,19 +87,19 @@ class GoogleServicesPlugin implements Plugin<Project> {
     showWarningForPluginLocation(project)
 
     // Setup google-services plugin after android plugin is applied.
-    project.plugins.withId("android", {
+    project.plugins.withId("android") {
       setupPlugin(project, PluginType.APPLICATION)
-    })
-    project.plugins.withId("android-library", {
+    }
+    project.plugins.withId("android-library") {
       setupPlugin(project, PluginType.LIBRARY)
-    })
-    project.plugins.withId("android-feature", {
+    }
+    project.plugins.withId("android-feature") {
       setupPlugin(project, PluginType.FEATURE)
-    })
+    }
   }
 
   private void showWarningForPluginLocation(Project project) {
-    project.getLogger().warn(
+    project.logger.warn(
         "Warning: Please apply google-services plugin at the bottom of the build file.")
   }
 
@@ -145,7 +145,8 @@ class GoogleServicesPlugin implements Plugin<Project> {
          GoogleServicesTask)
 
     task.setIntermediateDir(outputDir)
-    task.setVariantDir(variant.dirName)
+    task.setBuildType(variant.buildType.name)
+    task.setProductFlavors(variant.productFlavors.collect { it.name })
 
     // This is necessary for backwards compatibility with versions of gradle that do not support
     // this new API.

--- a/google-services-plugin/src/test/java/com/google/gms/googleservices/GoogleServicesPluginTest.java
+++ b/google-services-plugin/src/test/java/com/google/gms/googleservices/GoogleServicesPluginTest.java
@@ -19,6 +19,8 @@ package com.google.gms.googleservices;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -27,14 +29,14 @@ public class GoogleServicesPluginTest {
 
   @Test
   public void testNoFlavor() {
-    List<String> output = toStringList(GoogleServicesTask.getJsonLocations("release"));
+    List<String> output = toStringList(GoogleServicesTask.getJsonLocations("release", Collections.emptyList()));
     assertThat(output).contains("src/release");
   }
 
   @Test
   public void testOneFlavor() {
     List<String> output =
-        toStringList(GoogleServicesTask.getJsonLocations("flavor/release"));
+        toStringList(GoogleServicesTask.getJsonLocations("release", Collections.singletonList("flavor")));
     assertThat(output)
         .containsAllOf(
             "src/release",
@@ -47,7 +49,7 @@ public class GoogleServicesPluginTest {
   @Test
   public void testMultipleFlavors() {
     List<String> output =
-        toStringList(GoogleServicesTask.getJsonLocations("flavorTest/release"));
+        toStringList(GoogleServicesTask.getJsonLocations("release", Arrays.asList("flavor", "test")));
     assertThat(output)
         .containsAllOf(
             "src/release",


### PR DESCRIPTION
I have a project with two dimensions. The brands are named in `lowerCamelCase`, so I may have an uppercase character in the name of the brand.
Unfortunately, the current version of the Play Services Plugin does not work with those names, as we split the `variant.dirName` by uppercase characters to get all different flavors – which is not correct in my situation.

I refactored the `GoogleServicesTask` to use the names of the existing fields `buildType` and `productFlavors`. Using this approach, we don't have to use regular expressions at all.