### PR TITLE
Close reader on google-services.json that locks the file on Windows.

### DIFF
--- a/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesTask.java
+++ b/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesTask.java
@@ -35,6 +35,7 @@ import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -160,7 +161,9 @@ public class GoogleServicesTask extends DefaultTask {
       throw new GradleException("Failed to create folder: " + intermediateDir);
     }
 
-    JsonElement root = new JsonParser().parse(Files.newReader(quickstartFile, Charsets.UTF_8));
+    Reader jsonReader = Files.newReader(quickstartFile, Charsets.UTF_8);
+    JsonElement root = new JsonParser().parse(jsonReader);
+    jsonReader.close();
 
     if (!root.isJsonObject()) {
       throw new GradleException("Malformed root json");


### PR DESCRIPTION
My windows machine is not  automatically closing the stream, which does not release the resource.
I believe it's best practice to close a stream as soon as we don't need it anymore anyway.