### PR TITLE
oss-licenses-plugin: Adjust log level of DependencyTask for failed dependency resolving

### DIFF
--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyTask.groovy
@@ -198,7 +198,7 @@ class DependencyTask extends DefaultTask {
                             .getLenientConfiguration()
                             .getFirstLevelModuleDependencies())
         } catch (ResolveException exception) {
-            logger.warn("Failed to resolve OSS licenses for $configuration.name.", exception)
+            logger.info("Failed to resolve OSS licenses for $configuration.name.", exception)
             return null
         }
     }
@@ -223,7 +223,7 @@ class DependencyTask extends DefaultTask {
                     resolvedArtifacts.addAll(resolvedDependency.getAllModuleArtifacts())
                 }
             } catch (AmbiguousVariantSelectionException exception) {
-                logger.warn("Failed to process $resolvedDependency.name", exception)
+                logger.info("Failed to process $resolvedDependency.name", exception)
             }
         }
         return resolvedArtifacts


### PR DESCRIPTION
Fixed #141