### PR TITLE
Make DependencyTask cacheable/incremental

### DIFF
--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyTask.groovy
@@ -25,8 +25,8 @@ import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.ResolveException
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.ResolvedDependency
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.component.AmbiguousVariantSelectionException
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory
  * Finally it generates a json file that contains the information about these
  * artifacts.
  */
+@CacheableTask
 class DependencyTask extends DefaultTask {
     protected Set<String> artifactSet = []
     protected Set<ArtifactInfo> artifactInfos = []
@@ -56,14 +57,15 @@ class DependencyTask extends DefaultTask {
 
     private static final logger = LoggerFactory.getLogger(DependencyTask.class)
 
-    @Input
     public ConfigurationContainer configurations
 
-    @OutputDirectory
-    public File outputDir
+    @InputFiles
+    Set<File> buildFiles
+
+    File outputDir
 
     @OutputFile
-    public File outputFile
+    File outputFile
 
     @TaskAction
     void action() {

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyTask.groovy
@@ -59,6 +59,9 @@ class DependencyTask extends DefaultTask {
 
     public ConfigurationContainer configurations
 
+    /**
+     * Collection of all build.gradle files, only used as input cache key.
+     */
     @InputFiles
     Set<File> buildFiles
 

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
@@ -31,6 +31,8 @@ class OssLicensesPlugin implements Plugin<Project> {
         getDependencies.outputDir = dependencyOutput
         getDependencies.outputFile = generatedJson
 
+        // Collect all build.gradle files used in this project (and subprojects) to be used
+        // as input cache key for the DependencyTask, to run the task only if dependencies changed.
         def allBuildFiles = new HashSet<File>()
         project.getRootProject().subprojects.forEach { allBuildFiles.add(it.buildFile) }
         getDependencies.buildFiles = allBuildFiles

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
@@ -31,6 +31,10 @@ class OssLicensesPlugin implements Plugin<Project> {
         getDependencies.outputDir = dependencyOutput
         getDependencies.outputFile = generatedJson
 
+        def allBuildFiles = new HashSet<File>()
+        project.getRootProject().subprojects.forEach { allBuildFiles.add(it.buildFile) }
+        getDependencies.buildFiles = allBuildFiles
+
         def resourceOutput = new File(dependencyOutput, "/res")
         def outputDir = new File(resourceOutput, "/raw")
         def licensesFile = new File(outputDir, "third_party_licenses")


### PR DESCRIPTION
To address the issue https://github.com/google/play-services-plugins/issues/68 make `com.google.android.gms.oss.licenses.plugin.DependencyTask` cachable by using all build.gradle files of the project as input cache key.
The assumption behind this is that you have to change dependencies in `build.gradle` to have a change in the generated/used licenses.
Previously the `ConfigurationContainer` was used as input, but that doesn't work because it is not `Serializable`.
As output only the single file is declared, because on the output directory the exclusive access (for caching required, see: https://guides.gradle.org/using-build-cache/#concepts_overlapping_outputs) can't be guaranteed and this is the only file generated anyway.

<img width="695" alt="Bildschirmfoto 2020-09-11 um 16 08 40" src="https://user-images.githubusercontent.com/2677030/92941488-b6d20680-f450-11ea-89af-1310b3eb3cef.png">
