### PR TITLE
Use a Set rather than a List to store dependency relationships

### DIFF
--- a/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/DataObjects.kt
+++ b/strict-version-matcher-plugin/src/main/java/com/google/android/gms/dependencies/DataObjects.kt
@@ -102,16 +102,16 @@ data class Dependency(val fromArtifactVersion: ArtifactVersion, val toArtifact: 
 class ArtifactDependencyManager {
   /** Synchronized access to the dependencies to ensure elements aren't added while it's being iterated to provide a copy via the getter. */
   private val dependencyLock = Object()
-  @VisibleForTesting internal val dependencies: HashMap<Artifact, ArrayList<Dependency>> = HashMap()
+  @VisibleForTesting internal val dependencies: HashMap<Artifact, HashSet<Dependency>> = HashMap()
 
   fun addDependency(dependency: Dependency) {
     synchronized(dependencyLock) {
-      var depListForArtifact = dependencies.get(dependency.toArtifact)
-      if (depListForArtifact == null) {
-        depListForArtifact = ArrayList()
-        dependencies[dependency.toArtifact] = depListForArtifact
+      var depSetForArtifact = dependencies.get(dependency.toArtifact)
+      if (depSetForArtifact == null) {
+        depSetForArtifact = HashSet()
+        dependencies[dependency.toArtifact] = depSetForArtifact
       }
-      depListForArtifact.add(dependency)
+      depSetForArtifact.add(dependency)
     }
     // TODO: Check for conflicting duplicate adds and fail.
   }

--- a/strict-version-matcher-plugin/src/test/java/com/google/android/gms/dependencies/DataObjectsTest.kt
+++ b/strict-version-matcher-plugin/src/test/java/com/google/android/gms/dependencies/DataObjectsTest.kt
@@ -1,5 +1,6 @@
 package com.google.android.gms.dependencies
 
+import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
@@ -26,5 +27,14 @@ class DataObjectsTest {
     // original set of dependencies in a thread-unsafe way.
     manager.addDependency(Dependency(ARTIFACT_A_100, ARTIFACT_B_300.getArtifact(), "9.9.9"))
     iterator.next()
+  }
+
+  @Test
+  fun testAddDependency_sameDependencyTwiceOnlyRegisteredOnce() {
+    val manager = ArtifactDependencyManager()
+    manager.addDependency(Dependency(ARTIFACT_A_100, ARTIFACT_B_100.getArtifact(), ARTIFACT_B_100.version))
+    manager.addDependency(Dependency(ARTIFACT_A_100, ARTIFACT_B_100.getArtifact(), ARTIFACT_B_100.version))
+
+    Assert.assertEquals(1, manager.dependencies[ARTIFACT_B_100.getArtifact()]?.size)
   }
 }


### PR DESCRIPTION
Using a List means any dependency encountered more than once will be stored multiple times which unnecessarily consumes memory. The class API returns a Set for the dependency list, so using a Set internally does not alter the behavior of the class whilst giving a memory saving on dependency graphs where the same relationship might be encountered multiple times (e.g. over the course of multiple builds)

I've added a test which demonstrates the duplicate use problem. With the existing code this test will fail due to storing multiple copies of the same relationship.