### PR TITLE
Make oss-licenses-plugin compatible with Gradle 7

### DIFF
--- a/oss-licenses-plugin/README.md
+++ b/oss-licenses-plugin/README.md
@@ -34,7 +34,7 @@ and add the oss-licenses plugin to your dependencies:
       dependencies {
         // ...
         // Add this line:
-        classpath 'com.google.android.gms:oss-licenses-plugin:0.10.2'
+        classpath 'com.google.android.gms:oss-licenses-plugin:0.10.3'
       }
 
 In your app-level `build.gradle`, apply the plugin by adding the following line

--- a/oss-licenses-plugin/build.gradle
+++ b/oss-licenses-plugin/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'groovy'
 apply plugin: 'java'
 
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
 dependencies {
     implementation gradleApi()
     implementation localGroovy()
@@ -10,7 +13,7 @@ dependencies {
 }
 
 group = 'com.google.android.gms'
-version = '0.10.2'
+version = '0.10.3'
 
 apply plugin: 'maven'
 

--- a/oss-licenses-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/oss-licenses-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyTask.groovy
@@ -86,17 +86,18 @@ class DependencyTask extends DefaultTask {
      * false otherwise
      */
     protected boolean checkArtifactSet(File file) {
+        Set<String> artifacts = new HashSet<>(artifactSet)
         try {
             def previousArtifacts = new JsonSlurper().parse(file)
             for (entry in previousArtifacts) {
                 String key = "${entry.fileLocation}"
-                if (artifactSet.contains(key)) {
-                    artifactSet.remove(key)
+                if (artifacts.contains(key)) {
+                    artifacts.remove(key)
                 } else {
                     return false
                 }
             }
-            return artifactSet.isEmpty()
+            return artifacts.isEmpty()
         } catch (JsonException exception) {
             return false
         }

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyTask.groovy
@@ -20,8 +20,12 @@ import groovy.json.JsonBuilder
 import groovy.json.JsonException
 import groovy.json.JsonSlurper
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.ExternalModuleDependency
+import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.ResolveException
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.ResolvedDependency
@@ -56,14 +60,57 @@ class DependencyTask extends DefaultTask {
 
     private static final logger = LoggerFactory.getLogger(DependencyTask.class)
 
-    @Input
-    public ConfigurationContainer configurations
+    private ConfigurationContainer configurations
 
     @OutputDirectory
-    public File outputDir
+    File outputDir
 
     @OutputFile
-    public File outputFile
+    File outputFile
+
+    /**
+     * Returns a serializable snapshot of direct dependencies from all relevant
+     * configurations to allow task caching. To improve performance, this does
+     * not resolve transitive dependencies. Direct dependencies should require a
+     * version bump to publish a new POM file with updated transitive
+     * dependencies.
+     */
+    @Input
+    List<String> getDirectDependencies() {
+        return collectDependenciesFromConfigurations(configurations)
+    }
+
+    protected List<String> collectDependenciesFromConfigurations(
+            ConfigurationContainer configurationContainer
+    ) {
+        Set<String> directDependencies = new HashSet<>()
+        Set<Project> libraryProjects = new HashSet<>()
+        for (Configuration configuration in configurationContainer) {
+            if (shouldSkipConfiguration(configuration)) {
+                continue
+            }
+
+            for (Dependency dependency in configuration.allDependencies) {
+                if (dependency instanceof ProjectDependency) {
+                    libraryProjects.add(dependency.getDependencyProject())
+                } else if (dependency instanceof ExternalModuleDependency) {
+                    directDependencies.add(toMavenId(dependency))
+                }
+            }
+        }
+        for (Project libraryProject in libraryProjects) {
+            directDependencies.addAll(
+                    collectDependenciesFromConfigurations(
+                            libraryProject.getConfigurations()
+                    )
+            )
+        }
+        return directDependencies.sort()
+    }
+
+    protected static String toMavenId(Dependency dependency) {
+        return "${dependency.getGroup()}:${dependency.getName()}:${dependency.getVersion()}"
+    }
 
     @TaskAction
     void action() {
@@ -182,14 +229,8 @@ class DependencyTask extends DefaultTask {
 
     protected Set<ResolvedArtifact> getResolvedArtifacts(
             Configuration configuration) {
-        /**
-         * skip the configurations that, cannot be resolved in
-         * newer version of gradle api, are tests, or are not packaged dependencies.
-         */
 
-        if (!canBeResolved(configuration)
-                || isTest(configuration)
-                || !isPackagedDependency(configuration)) {
+        if (shouldSkipConfiguration(configuration)) {
             return null
         }
 
@@ -202,6 +243,16 @@ class DependencyTask extends DefaultTask {
             logger.warn("Failed to resolve OSS licenses for $configuration.name.", exception)
             return null
         }
+    }
+
+    /**
+     * Returns true for configurations that cannot be resolved in the newer
+     * version of gradle API, are tests, or are not packaged dependencies.
+     */
+    private boolean shouldSkipConfiguration(Configuration configuration) {
+        (!canBeResolved(configuration)
+                || isTest(configuration)
+                || !isPackagedDependency(configuration))
     }
 
     protected Set<ResolvedArtifact> getResolvedArtifactsFromResolvedDependencies(
@@ -234,5 +285,9 @@ class DependencyTask extends DefaultTask {
         if (!outputDir.exists()) {
             outputDir.mkdirs()
         }
+    }
+
+    void setConfigurations(configurations) {
+        this.configurations = configurations
     }
 }

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesCleanUpTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesCleanUpTask.groovy
@@ -17,7 +17,6 @@
 package com.google.android.gms.oss.licenses.plugin
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 
 /**
@@ -25,20 +24,16 @@ import org.gradle.api.tasks.TaskAction
  * third_party_license_metadata files.
  */
 class LicensesCleanUpTask extends DefaultTask {
-    @Input
-    public File dependencyFile
 
-    @Input
-    public File dependencyDir
+    protected File dependencyFile
 
-    @Input
-    public File licensesFile
+    protected File dependencyDir
 
-    @Input
-    public File metadataFile
+    protected File licensesFile
 
-    @Input
-    public File licensesDir
+    protected File metadataFile
+
+    protected File licensesDir
 
     @TaskAction
     void action() {

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
@@ -57,16 +57,16 @@ class LicensesTask extends DefaultTask {
     protected Map<String, String> licensesMap = [:]
 
     @InputFile
-    public File dependenciesJson
+    File dependenciesJson
 
     @OutputDirectory
-    public File outputDir
+    File outputDir
 
     @OutputFile
-    public File licenses
+    File licenses
 
     @OutputFile
-    public File licensesMetadata
+    File licensesMetadata
 
     @TaskAction
     void action() {

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
@@ -27,7 +27,7 @@ class OssLicensesPlugin implements Plugin<Project> {
         def dependencyOutput = new File(project.buildDir,
             "generated/third_party_licenses")
         def generatedJson = new File(dependencyOutput, "dependencies.json")
-        getDependencies.configurations = project.getConfigurations()
+        getDependencies.setConfigurations(project.getConfigurations())
         getDependencies.outputDir = dependencyOutput
         getDependencies.outputFile = generatedJson
 

--- a/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/DependencyTaskTest.java
+++ b/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/DependencyTaskTest.java
@@ -23,18 +23,26 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.DependencySet;
+import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.LenientConfiguration;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
@@ -50,6 +58,7 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link DependencyTask} */
 @RunWith(JUnit4.class)
 public class DependencyTaskTest {
+
   private Project project;
   private DependencyTask dependencyTask;
 
@@ -60,10 +69,218 @@ public class DependencyTaskTest {
   }
 
   @Test
+  public void collectDependenciesFromConfigurations_multipleConfigs_combined() {
+    List<String> compileExpectedIds = Arrays.asList(
+        "com.example:real-dependency:1.2.3",
+        "com.example:totally-useful:4.5.6"
+    );
+    Configuration compileConfiguration = mockConfiguration(
+        "compile",
+        /* canBeResolved = */ true,
+        compileExpectedIds);
+    List<String> apiExpectedIds = Arrays.asList(
+        "com.example:api-thing:1.2.3",
+        "com.example:idk-rpc:4.5.6"
+    );
+    Configuration apiConfiguration = mockConfiguration(
+        "api",
+        /* canBeResolved = */ true,
+        apiExpectedIds);
+    ConfigurationContainer configurationContainer = mock(ConfigurationContainer.class);
+    when(configurationContainer.iterator())
+        .thenReturn(Arrays.asList(compileConfiguration, apiConfiguration).iterator());
+    List<String> allExpectedIds = new ArrayList<>(compileExpectedIds);
+    allExpectedIds.addAll(apiExpectedIds);
+    Collections.sort(allExpectedIds);
+
+    List<String> dependencies = dependencyTask
+        .collectDependenciesFromConfigurations(configurationContainer);
+    Collections.sort(dependencies);
+
+    verify(compileConfiguration, times(1)).getAllDependencies();
+    verify(apiConfiguration, times(1)).getAllDependencies();
+    assertThat(dependencies, is(allExpectedIds));
+  }
+
+  @Test
+  public void collectDependenciesFromConfigurations_libraryProject_combined() {
+    List<String> libraryProjectExpectedIds = Arrays.asList(
+        "com.example:api-thing:1.2.3",
+        "com.example:idk-rpc:4.5.6"
+    );
+    Configuration libraryConfiguration = mockConfiguration(
+        "compile",
+        /* canBeResolved = */ true,
+        libraryProjectExpectedIds);
+    Project libraryProject = mock(Project.class);
+    ConfigurationContainer libraryConfigurationContainer = mock(ConfigurationContainer.class);
+    when(libraryConfigurationContainer.iterator())
+        .thenReturn(Collections.singletonList(libraryConfiguration).iterator());
+    when(libraryProject.getConfigurations()).thenReturn(libraryConfigurationContainer);
+    ProjectDependency libraryProjectDependency = mockDependency(
+        ProjectDependency.class, "this:is:ignored");
+    when(libraryProjectDependency.getDependencyProject()).thenReturn(libraryProject);
+
+    List<String> compileExpectedIds = Arrays.asList(
+        "com.example:real-dependency:1.2.3",
+        "com.example:totally-useful:4.5.6"
+    );
+    DependencySet dependencySet = mockDependencySet(new HashSet<Dependency>() {{
+      add(libraryProjectDependency);
+      add(mockDependency(ExternalModuleDependency.class, compileExpectedIds.get(0)));
+      add(mockDependency(ExternalModuleDependency.class, compileExpectedIds.get(1)));
+    }});
+    Configuration compileConfiguration = mockConfiguration(
+        "compile",
+        /* canBeResolved = */ true,
+        dependencySet);
+    ConfigurationContainer configurationContainer = mock(ConfigurationContainer.class);
+    when(configurationContainer.iterator())
+        .thenReturn(Collections.singletonList(compileConfiguration).iterator());
+    List<String> allExpectedIds = new ArrayList<>(compileExpectedIds);
+    allExpectedIds.addAll(libraryProjectExpectedIds);
+    Collections.sort(allExpectedIds);
+
+    List<String> dependencies = dependencyTask
+        .collectDependenciesFromConfigurations(configurationContainer);
+    Collections.sort(dependencies);
+
+    verify(compileConfiguration, times(1)).getAllDependencies();
+    verify(libraryConfiguration, times(1)).getAllDependencies();
+    assertThat(dependencies, is(allExpectedIds));
+  }
+
+  @Test
+  public void collectDependenciesFromConfigurations_withTestConfig_ignored() {
+    List<String> expectedIds = Arrays.asList(
+        "com.example:real-dependency:1.2.3",
+        "com.example:totally-useful:4.5.6"
+    );
+    Configuration compileConfiguration = mockConfiguration(
+        "compile",
+        /* canBeResolved = */ true,
+        expectedIds);
+    List<String> unexpectedIds = Arrays.asList(
+        "com.test-only:test-thing:1.2.3",
+        "com.test-only:not-shipped:4.5.6"
+    );
+    Configuration testConfiguration = mockConfiguration(
+        "testCompile",
+        /* canBeResolved = */ true,
+        unexpectedIds);
+    ConfigurationContainer configurationContainer = mock(ConfigurationContainer.class);
+    when(configurationContainer.iterator())
+        .thenReturn(Arrays.asList(compileConfiguration, testConfiguration).iterator());
+
+    List<String> dependencies = dependencyTask
+        .collectDependenciesFromConfigurations(configurationContainer);
+    Collections.sort(dependencies);
+
+    verify(compileConfiguration, times(1)).getAllDependencies();
+    verify(testConfiguration, never()).getAllDependencies();
+    assertThat(dependencies, is(expectedIds));
+  }
+
+  @Test
+  public void collectDependenciesFromConfigurations_withUnresolvableConfig_ignored() {
+    List<String> expectedIds = Arrays.asList(
+        "com.example:real-dependency:1.2.3",
+        "com.example:totally-useful:4.5.6"
+    );
+    Configuration compileConfiguration = mockConfiguration(
+        "compile",
+        /* canBeResolved = */ true,
+        expectedIds);
+    List<String> unexpectedIds = Arrays.asList(
+        "com.mystery:unresolvable:1.2.3",
+        "com.enigma:dont-resolve-this:4.5.6"
+    );
+    Configuration unresolvableConfiguration = mockConfiguration(
+        "api",
+        /* canBeResolved = */ false,
+        unexpectedIds);
+    ConfigurationContainer configurationContainer = mock(ConfigurationContainer.class);
+    when(configurationContainer.iterator())
+        .thenReturn(Arrays.asList(compileConfiguration, unresolvableConfiguration).iterator());
+
+    List<String> dependencies = dependencyTask
+        .collectDependenciesFromConfigurations(configurationContainer);
+    Collections.sort(dependencies);
+
+    verify(compileConfiguration, times(1)).getAllDependencies();
+    verify(unresolvableConfiguration, never()).getAllDependencies();
+    assertThat(dependencies, is(expectedIds));
+  }
+
+  @Test
+  public void collectDependenciesFromConfigurations_unusableDependencyClass_ignored() {
+    List<String> expectedIds = Collections.singletonList("should.be:alone:4.5.6");
+    DependencySet dependencySet = mockDependencySet(new HashSet<Dependency>() {{
+      add(mockDependency(Dependency.class, "should.be:skipped:1.2.3"));
+      add(mockDependency(ExternalModuleDependency.class, expectedIds.get(0)));
+    }});
+    Configuration configuration = mockConfiguration(
+        "compile",
+        /* canBeResolved = */ true,
+        dependencySet);
+    ConfigurationContainer configurationContainer = mock(ConfigurationContainer.class);
+    when(configurationContainer.iterator())
+        .thenReturn(Collections.singletonList(configuration).iterator());
+
+    List<String> dependencies = dependencyTask
+        .collectDependenciesFromConfigurations(configurationContainer);
+    Collections.sort(dependencies);
+
+    verify(configuration, times(1)).getAllDependencies();
+    assertThat(dependencies, is(expectedIds));
+  }
+
+  private Configuration mockConfiguration(String name, boolean canBeResolved,
+      List<String> mavenIds) {
+    DependencySet dependencies = mockDependencySet(mavenIds);
+    return mockConfiguration(name, canBeResolved, dependencies);
+  }
+
+  private Configuration mockConfiguration(String name, boolean canBeResolved,
+      DependencySet dependencies) {
+    Configuration configuration = mock(Configuration.class);
+    when(configuration.getName()).thenReturn(name);
+    when(configuration.isCanBeResolved()).thenReturn(canBeResolved);
+    when(configuration.getAllDependencies()).thenReturn(dependencies);
+    return configuration;
+  }
+
+  private DependencySet mockDependencySet(List<String> mavenIds) {
+    Set<Dependency> dependencies = new HashSet<>();
+    for (String mavenId : mavenIds) {
+      dependencies.add(mockDependency(ExternalModuleDependency.class, mavenId));
+    }
+    return mockDependencySet(dependencies);
+  }
+
+  private DependencySet mockDependencySet(Set<Dependency> dependencies) {
+    DependencySet dependencySet = mock(DependencySet.class);
+    when(dependencySet.iterator()).thenReturn(dependencies.iterator());
+    return dependencySet;
+  }
+
+  private <T extends Dependency> T mockDependency(
+      Class<T> dependencyClass,
+      String mavenId
+  ) {
+    T dependency = mock(dependencyClass);
+    String[] mavenIdFields = mavenId.split(":");
+    when(dependency.getGroup()).thenReturn(mavenIdFields[0]);
+    when(dependency.getName()).thenReturn(mavenIdFields[1]);
+    when(dependency.getVersion()).thenReturn(mavenIdFields[2]);
+    return dependency;
+  }
+
+  @Test
   public void testCheckArtifactSet_missingSet() {
     File dependencies = new File("src/test/resources", "testDependency.json");
     String[] artifactSet =
-        new String[] {"dependencies/groupA/deps1.txt", "dependencies/groupB/abc/deps2.txt"};
+        new String[]{"dependencies/groupA/deps1.txt", "dependencies/groupB/abc/deps2.txt"};
     dependencyTask.artifactSet = new HashSet<>(Arrays.asList(artifactSet));
 
     assertFalse(dependencyTask.checkArtifactSet(dependencies));

--- a/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/LicensesTaskTest.java
+++ b/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/LicensesTaskTest.java
@@ -65,9 +65,9 @@ public class LicensesTaskTest {
     project = ProjectBuilder.builder().withProjectDir(new File(BASE_DIR)).build();
     licensesTask = project.getTasks().create("generateLicenses", LicensesTask.class);
 
-    licensesTask.outputDir = outputDir;
-    licensesTask.licenses = outputLicenses;
-    licensesTask.licensesMetadata = outputMetadata;
+    licensesTask.setOutputDir(outputDir);
+    licensesTask.setLicenses(outputLicenses);
+    licensesTask.setLicensesMetadata(outputMetadata);
   }
 
   private void createLicenseZip(String name) throws IOException {
@@ -88,23 +88,23 @@ public class LicensesTaskTest {
   public void testInitOutputDir() {
     licensesTask.initOutputDir();
 
-    assertTrue(licensesTask.outputDir.exists());
+    assertTrue(licensesTask.getOutputDir().exists());
   }
 
   @Test
   public void testInitLicenseFile() throws IOException {
     licensesTask.initLicenseFile();
 
-    assertTrue(licensesTask.licenses.exists());
-    assertEquals(0, Files.size(licensesTask.licenses.toPath()));
+    assertTrue(licensesTask.getLicenses().exists());
+    assertEquals(0, Files.size(licensesTask.getLicenses().toPath()));
   }
 
   @Test
   public void testInitLicensesMetadata() throws IOException {
     licensesTask.initLicensesMetadata();
 
-    assertTrue(licensesTask.licensesMetadata.exists());
-    assertEquals(0, Files.size(licensesTask.licensesMetadata.toPath()));
+    assertTrue(licensesTask.getLicensesMetadata().exists());
+    assertEquals(0, Files.size(licensesTask.getLicensesMetadata().toPath()));
   }
 
   @Test
@@ -126,7 +126,7 @@ public class LicensesTaskTest {
     String group1 = "groupA";
     licensesTask.addLicensesFromPom(deps1, group1, name1);
 
-    String content = new String(Files.readAllBytes(licensesTask.licenses.toPath()), UTF_8);
+    String content = new String(Files.readAllBytes(licensesTask.getLicenses().toPath()), UTF_8);
     String expected = "http://www.opensource.org/licenses/mit-license.php" + LINE_BREAK;
     assertTrue(licensesTask.licensesMap.containsKey("groupA:deps1"));
     assertEquals(expected, content);
@@ -144,7 +144,7 @@ public class LicensesTaskTest {
     String group2 = "groupB";
     licensesTask.addLicensesFromPom(deps2, group2, name2);
 
-    String content = new String(Files.readAllBytes(licensesTask.licenses.toPath()), UTF_8);
+    String content = new String(Files.readAllBytes(licensesTask.getLicenses().toPath()), UTF_8);
     String expected =
         "http://www.opensource.org/licenses/mit-license.php"
             + LINE_BREAK
@@ -169,7 +169,7 @@ public class LicensesTaskTest {
     String group2 = "groupE";
     licensesTask.addLicensesFromPom(deps2, group2, name2);
 
-    String content = new String(Files.readAllBytes(licensesTask.licenses.toPath()), UTF_8);
+    String content = new String(Files.readAllBytes(licensesTask.getLicenses().toPath()), UTF_8);
     String expected =
         "http://www.opensource.org/licenses/mit-license.php"
             + LINE_BREAK
@@ -197,7 +197,7 @@ public class LicensesTaskTest {
     String group2 = "groupA";
     licensesTask.addLicensesFromPom(deps2, group2, name2);
 
-    String content = new String(Files.readAllBytes(licensesTask.licenses.toPath()), UTF_8);
+    String content = new String(Files.readAllBytes(licensesTask.getLicenses().toPath()), UTF_8);
     String expected = "http://www.opensource.org/licenses/mit-license.php" + LINE_BREAK;
 
     assertThat(licensesTask.licensesMap.size(), is(1));
@@ -239,13 +239,13 @@ public class LicensesTaskTest {
 
   @Test
   public void testAddGooglePlayServiceLicenses() throws IOException {
-    File tempOutput = new File(licensesTask.outputDir, "dependencies/groupC");
+    File tempOutput = new File(licensesTask.getOutputDir(), "dependencies/groupC");
     tempOutput.mkdirs();
     createLicenseZip(tempOutput.getPath() + "play-services-foo-license.aar");
     File artifact = new File(tempOutput.getPath() + "play-services-foo-license.aar");
     licensesTask.addGooglePlayServiceLicenses(artifact);
 
-    String content = new String(Files.readAllBytes(licensesTask.licenses.toPath()), UTF_8);
+    String content = new String(Files.readAllBytes(licensesTask.getLicenses().toPath()), UTF_8);
     String expected = "safeparcel" + LINE_BREAK + "JSR 305" + LINE_BREAK;
     assertEquals(expected, content);
     assertThat(licensesTask.googleServiceLicenses.size(), is(2));
@@ -258,12 +258,12 @@ public class LicensesTaskTest {
 
   @Test
   public void testAddGooglePlayServiceLicenses_withoutDuplicate() throws IOException {
-    File groupC = new File(licensesTask.outputDir, "dependencies/groupC");
+    File groupC = new File(licensesTask.getOutputDir(), "dependencies/groupC");
     groupC.mkdirs();
     createLicenseZip(groupC.getPath() + "/play-services-foo-license.aar");
     File artifactFoo = new File(groupC.getPath() + "/play-services-foo-license.aar");
 
-    File groupD = new File(licensesTask.outputDir, "dependencies/groupD");
+    File groupD = new File(licensesTask.getOutputDir(), "dependencies/groupD");
     groupD.mkdirs();
     createLicenseZip(groupD.getPath() + "/play-services-bar-license.aar");
     File artifactBar = new File(groupD.getPath() + "/play-services-bar-license.aar");
@@ -271,7 +271,7 @@ public class LicensesTaskTest {
     licensesTask.addGooglePlayServiceLicenses(artifactFoo);
     licensesTask.addGooglePlayServiceLicenses(artifactBar);
 
-    String content = new String(Files.readAllBytes(licensesTask.licenses.toPath()), UTF_8);
+    String content = new String(Files.readAllBytes(licensesTask.getLicenses().toPath()), UTF_8);
     String expected = "safeparcel" + LINE_BREAK + "JSR 305" + LINE_BREAK;
     assertEquals(expected, content);
     assertThat(licensesTask.googleServiceLicenses.size(), is(2));
@@ -287,7 +287,7 @@ public class LicensesTaskTest {
     licensesTask.appendLicense("license1", "test".getBytes(UTF_8));
 
     String expected = "test" + LINE_BREAK;
-    String content = new String(Files.readAllBytes(licensesTask.licenses.toPath()), UTF_8);
+    String content = new String(Files.readAllBytes(licensesTask.getLicenses().toPath()), UTF_8);
     assertTrue(licensesTask.licensesMap.containsKey("license1"));
     assertEquals(expected, content);
   }
@@ -299,7 +299,7 @@ public class LicensesTaskTest {
     licensesTask.writeMetadata();
 
     String expected = "0:4 license1" + LINE_BREAK + "6:10 license2" + LINE_BREAK;
-    String content = new String(Files.readAllBytes(licensesTask.licensesMetadata.toPath()), UTF_8);
+    String content = new String(Files.readAllBytes(licensesTask.getLicensesMetadata().toPath()), UTF_8);
     assertEquals(expected, content);
   }
 }


### PR DESCRIPTION
This set of changes will make the tasks compatible with Gradle 7 as well as making the tasks cacheable. The largest change was to the DependencyTask class where a new `@Input` annotated method was created. This returns a serializable, sorted list from the set of direct dependencies for the app and any library projects.

Gradle 7 deprecation warnings were based on the use of a Groovy `field` instead of a `property`. Additionally, the previous `@Input` annotated field of `configurations` was not serializable so it could not be used as a key.
```
> Task :app:getDependencies
Type 'DependencyTask': field 'configurations' without corresponding getter has been annotated with @Input. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7.1/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
Type 'DependencyTask': field 'outputDir' without corresponding getter has been annotated with @OutputDirectory. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7.1/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
Type 'DependencyTask': field 'outputFile' without corresponding getter has been annotated with @OutputFile. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7.1/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.

> Task :app:generateLicenses UP-TO-DATE
Type 'LicensesTask': field 'dependenciesJson' without corresponding getter has been annotated with @InputFile. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7.1/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
Type 'LicensesTask': field 'outputDir' without corresponding getter has been annotated with @OutputDirectory. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7.1/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
Type 'LicensesTask': field 'licenses' without corresponding getter has been annotated with @OutputFile. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7.1/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
Type 'LicensesTask': field 'licensesMetadata' without corresponding getter has been annotated with @OutputFile. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7.1/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
```

fixes #68, fixes #146, fixes #165, fixes #166