### PR TITLE
Add oss-licenses-plugin support for dependency cycles in projects

### DIFF
--- a/oss-licenses-plugin/build.gradle
+++ b/oss-licenses-plugin/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 group = 'com.google.android.gms'
-version = '0.10.3'
+version = '0.10.4'
 
 apply plugin: 'maven'
 

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
@@ -27,7 +27,7 @@ class OssLicensesPlugin implements Plugin<Project> {
         def dependencyOutput = new File(project.buildDir,
             "generated/third_party_licenses")
         def generatedJson = new File(dependencyOutput, "dependencies.json")
-        getDependencies.setConfigurations(project.getConfigurations())
+        getDependencies.setProject(project)
         getDependencies.outputDir = dependencyOutput
         getDependencies.outputFile = generatedJson
 


### PR DESCRIPTION
Added handling for dependency cycles for projects by keeping track of previously visited projects and ignoring them if encountered again.

AGP 7.0.0-alpha12 `com.android.tools.build:gradle:7.0.0-alpha12` (possibly other versions) causes projects to list themselves as instances of `ProjectDependency` when iterating over `configuration.allDependencies` for configurations of that project. This causes a self-referential dependency cycle if naively performing a depth-first scan of `configuration.allDependencies` for each project and child project.

fixes #172 