### PR TITLE
Use the library name from the POM file of the dependency

### DIFF
--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
@@ -216,7 +216,10 @@ class LicensesTask extends DefaultTask {
             return
         }
 
-        String licenseKey = "${group}:${name}"
+        String licenseKey = rootNode.name
+        if (licenseKey == null || licenseKey == "") {
+            licenseKey = "${group}:${name}"
+        }
         if (rootNode.licenses.license.size() > 1) {
             rootNode.licenses.license.each { node ->
                 String nodeName = node.name


### PR DESCRIPTION
I want to have the clean name of the dependency if set in the POM file. My PR will use the name and will fallback when the name tag is not set in the POM file to the artifact group and artifact id.
Fixes #184 