### PR TITLE
Make the process<Configuration>GoogleServices tasks config avoidant

### DIFF
--- a/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesPlugin.groovy
+++ b/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesPlugin.groovy
@@ -123,7 +123,7 @@ class GoogleServicesPlugin implements Plugin<Project> {
 
     project
       .tasks
-      .create(
+      .register(
         "process${variant.name.capitalize()}GoogleServices",
          GoogleServicesTask) { task ->
           task.setIntermediateDir(outputDir)


### PR DESCRIPTION
Make the process<Configuration>GoogleServices tasks config avoidant

See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html

This does have the unfortunate side effect of the plugin not complaining about a missing `google-services.json` unless some `process<Configuration>GoogleServices` task gets run somehow.
However, that may be better for local development where the answer of how to get a relevant `google-services.json` can be postponed until after it builds at all. (Though I understand AndroidStudio is capable of handling `google-services.json`, it would still be good for those forced to use CLI development only).

TESTED: Verified by a really simple local android project. Without this change, it complained about `google-services.json` immediately. With this change, it only complained about it if `:processReleaseGoogleServices` or `:processDebugGoogleServices` was run (directly or indirectly)

Fixes: #180