### PR TITLE
Add the ability to manually include OSS licenses

### DIFF
--- a/oss-licenses-plugin/build.gradle
+++ b/oss-licenses-plugin/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'groovy'
 apply plugin: 'java'
+apply plugin: 'java-gradle-plugin'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -13,9 +14,10 @@ dependencies {
 }
 
 group = 'com.google.android.gms'
-version = '0.10.4'
+version = '0.10.4-roku'
 
 apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 repositories {
     google()

--- a/oss-licenses-plugin/build.gradle
+++ b/oss-licenses-plugin/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'groovy'
 apply plugin: 'java'
-apply plugin: 'java-gradle-plugin'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -14,10 +13,9 @@ dependencies {
 }
 
 group = 'com.google.android.gms'
-version = '0.10.4-roku'
+version = '0.10.4'
 
 apply plugin: 'maven'
-apply plugin: 'maven-publish'
 
 repositories {
     google()

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
@@ -27,6 +27,11 @@ class OssLicensesPlugin implements Plugin<Project> {
         def dependencyOutput = new File(project.buildDir,
             "generated/third_party_licenses")
         def generatedJson = new File(dependencyOutput, "dependencies.json")
+
+        def customDependencyOutput = new File(project.projectDir,
+                "src/main/res/raw")
+        def customGeneratedJson = new File(customDependencyOutput, "custom_dependencies.json")
+
         getDependencies.setProject(project)
         getDependencies.outputDir = dependencyOutput
         getDependencies.outputFile = generatedJson
@@ -39,6 +44,11 @@ class OssLicensesPlugin implements Plugin<Project> {
         def licenseTask = project.tasks.create("generateLicenses", LicensesTask)
 
         licenseTask.dependenciesJson = generatedJson
+
+        if (customGeneratedJson.exists()) {
+            licenseTask.customDependenciesJson = customGeneratedJson
+        }
+        
         licenseTask.outputDir = outputDir
         licenseTask.licenses = licensesFile
         licenseTask.licensesMetadata = licensesMetadataFile


### PR DESCRIPTION
Hello, this is a great library! I noticed the oss-licenses-plugin didn't have the ability to add licenses manually so I added that functionality. To test this PR:

1. Create `custom_dependencies.json` under `res/raw`
2. Add entries any number of manual entries in the following JSON format:
```
[
  {
    "group": "",
    "version": "1.2.0",
    "fileLocation": "custom",
    "name": "Speex",
    "license": "https://www.speex.org/docs/manual/speex-manual/node15.html#sec:Speex-License"
  },
  {
    "group": "some.group",
    "version": "1.2.3",
    "fileLocation": "custom",
    "name": "Some Library",
    "license": "Some Text or URL"
  }
]
```
3. Build and run the app like usual, enjoy

Let me know if you have any revisions!