### PR TITLE
Switch to using app dependency report from Android Gradle Plugin.

### DIFF
--- a/oss-licenses-plugin/build.gradle
+++ b/oss-licenses-plugin/build.gradle
@@ -7,19 +7,24 @@ targetCompatibility = 1.8
 dependencies {
     implementation gradleApi()
     implementation localGroovy()
-    implementation 'com.android.tools.build:gradle:3.5.1'
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.23.4'
+    implementation 'com.android.tools.build:gradle:7.1.0'
+    implementation 'com.android.tools.build:gradle-api:7.1.0'
+    implementation 'com.google.protobuf:protobuf-java:3.19.1'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:4.1.0'
+    testImplementation 'com.google.guava:guava:31.0.1-jre'
+    testImplementation 'com.google.truth:truth:1.1.3'
+    testImplementation 'com.google.code.gson:gson:2.8.9'
 }
 
 group = 'com.google.android.gms'
-version = '0.10.4'
+version = '0.10.5'
 
 apply plugin: 'maven'
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
 }
 
 // upload and build in local

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/ArtifactInfo.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/ArtifactInfo.groovy
@@ -19,16 +19,13 @@ package com.google.android.gms.oss.licenses.plugin
 class ArtifactInfo {
     private String group
     private String name
-    private String fileLocation
     private String version
 
     ArtifactInfo(String group,
-            String name,
-            String fileLocation,
-            String version) {
+                 String name,
+                 String version) {
         this.group = group
         this.name = name
-        this.fileLocation = fileLocation
         this.version = version
     }
 
@@ -40,11 +37,27 @@ class ArtifactInfo {
         return name
     }
 
-    String getFileLocation() {
-        return fileLocation
-    }
-
     String getVersion() {
         return version
+    }
+
+    @Override
+    boolean equals(Object obj) {
+        if (obj instanceof ArtifactInfo) {
+            return (group == obj.group
+                    && name == obj.name
+                    && version == obj.version)
+        }
+        return false
+    }
+
+    @Override
+    int hashCode() {
+        return group.hashCode() ^ name.hashCode() ^ version.hashCode()
+    }
+
+    @Override
+    String toString() {
+        return "$group:$name:$version"
     }
 }

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyTask.groovy
@@ -16,51 +16,29 @@
 
 package com.google.android.gms.oss.licenses.plugin
 
+import com.android.tools.build.libraries.metadata.AppDependencies
 import groovy.json.JsonBuilder
-import groovy.json.JsonException
-import groovy.json.JsonSlurper
 import org.gradle.api.DefaultTask
-import org.gradle.api.Project
-import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ConfigurationContainer
-import org.gradle.api.artifacts.Dependency
-import org.gradle.api.artifacts.ExternalModuleDependency
-import org.gradle.api.artifacts.ProjectDependency
-import org.gradle.api.artifacts.ResolveException
-import org.gradle.api.artifacts.ResolvedArtifact
-import org.gradle.api.artifacts.ResolvedDependency
-import org.gradle.api.tasks.Input
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-import org.gradle.internal.component.AmbiguousVariantSelectionException
 import org.slf4j.LoggerFactory
 
+import java.util.stream.Collectors
+
+import static com.android.tools.build.libraries.metadata.Library.LibraryOneofCase.MAVEN_LIBRARY
+
 /**
- * This task does the following:
- * First it finds all dependencies that meet all the requirements below:
- * 1. Can be resolved.
- * 2. Not test compile.
- * Then it finds all the artifacts associated with the dependencies.
- * Finally it generates a json file that contains the information about these
- * artifacts.
+ * Converts the AppDependencies protobuf file provided by the Android Gradle
+ * Plugin into a JSON format that will be consumed by the {@link LicensesTask}.
+ *
+ * If the protobuf is not present (e.g. debug variants) it writes a single
+ * dependency on the {@link DependencyUtil#ABSENT_ARTIFACT}.
  */
-class DependencyTask extends DefaultTask {
-    protected Set<String> artifactSet = []
-    protected Set<ArtifactInfo> artifactInfos = []
-    protected static final String LOCAL_LIBRARY_VERSION = "unspecified"
-    private static final String TEST_PREFIX = "test"
-    private static final String ANDROID_TEST_PREFIX = "androidTest"
-    private static final Set<String> TEST_COMPILE = ["testCompile",
-                                                     "androidTestCompile"]
-
-    private static final Set<String> PACKAGED_DEPENDENCIES_PREFIXES = ["compile",
-                                                                       "implementation",
-                                                                       "api"]
-
+abstract class DependencyTask extends DefaultTask {
     private static final logger = LoggerFactory.getLogger(DependencyTask.class)
-
-    private Project project
 
     @OutputDirectory
     File outputDir
@@ -68,236 +46,56 @@ class DependencyTask extends DefaultTask {
     @OutputFile
     File outputFile
 
-    /**
-     * Returns a serializable snapshot of direct dependencies from all relevant
-     * configurations to allow task caching. To improve performance, this does
-     * not resolve transitive dependencies. Direct dependencies should require a
-     * version bump to publish a new POM file with updated transitive
-     * dependencies.
-     */
-    @Input
-    List<String> getDirectDependencies() {
-        return collectDependenciesFromConfigurations(
-                project.getConfigurations(),
-                [project] as Set<Project>
-        )
-    }
-
-    protected List<String> collectDependenciesFromConfigurations(
-            ConfigurationContainer configurationContainer,
-            Set<Project> visitedProjects
-    ) {
-        Set<String> directDependencies = new HashSet<>()
-        Set<Project> libraryProjects = new HashSet<>()
-        for (Configuration configuration in configurationContainer) {
-            if (shouldSkipConfiguration(configuration)) {
-                continue
-            }
-
-            for (Dependency dependency in configuration.allDependencies) {
-                if (dependency instanceof ProjectDependency) {
-                    libraryProjects.add(dependency.getDependencyProject())
-                } else if (dependency instanceof ExternalModuleDependency) {
-                    directDependencies.add(toMavenId(dependency))
-                }
-            }
-        }
-        for (Project libraryProject in libraryProjects) {
-            if (libraryProject in visitedProjects) {
-                continue
-            }
-            visitedProjects.add(libraryProject)
-            logger.info("Visiting dependency ${libraryProject.displayName}")
-            directDependencies.addAll(
-                    collectDependenciesFromConfigurations(
-                            libraryProject.getConfigurations(),
-                            visitedProjects
-                    )
-            )
-        }
-        return directDependencies.sort()
-    }
-
-    protected static String toMavenId(Dependency dependency) {
-        return "${dependency.getGroup()}:${dependency.getName()}:${dependency.getVersion()}"
-    }
+    @InputFile
+    @org.gradle.api.tasks.Optional
+    abstract RegularFileProperty getLibraryDependenciesReport()
 
     @TaskAction
     void action() {
+        def artifactInfoSet = loadArtifactInfo()
+
         initOutput()
-        updateDependencyArtifacts()
-
-        if (outputFile.exists() && checkArtifactSet(outputFile)) {
-            return
+        outputFile.newWriter().withWriter {
+            it.write(new JsonBuilder(artifactInfoSet).toPrettyString())
         }
-
-        outputFile.newWriter()
-        outputFile.write(new JsonBuilder(artifactInfos).toPrettyString())
     }
 
-    /**
-     * Checks if current artifact set is the same as the artifact set in the
-     * json file
-     * @param file
-     * @return true if artifactSet is the same as the json file,
-     * false otherwise
-     */
-    protected boolean checkArtifactSet(File file) {
-        Set<String> artifacts = new HashSet<>(artifactSet)
-        try {
-            def previousArtifacts = new JsonSlurper().parse(file)
-            for (entry in previousArtifacts) {
-                String key = "${entry.fileLocation}"
-                if (artifacts.contains(key)) {
-                    artifacts.remove(key)
-                } else {
-                    return false
+    private Set<ArtifactInfo> loadArtifactInfo() {
+        if (!libraryDependenciesReport.isPresent()) {
+            logger.info("$name not provided with AppDependencies proto file.")
+            return [DependencyUtil.ABSENT_ARTIFACT]
+        }
+
+        AppDependencies appDependencies = loadDependenciesFile()
+
+        return convertDependenciesToArtifactInfo(appDependencies)
+    }
+
+    private AppDependencies loadDependenciesFile() {
+        File dependenciesFile = libraryDependenciesReport.asFile.get()
+        return dependenciesFile.withInputStream {
+            AppDependencies.parseFrom(it)
+        } as AppDependencies
+    }
+
+    private static Set<ArtifactInfo> convertDependenciesToArtifactInfo(
+            AppDependencies appDependencies
+    ) {
+        return appDependencies.libraryList.stream()
+                .filter { it.libraryOneofCase == MAVEN_LIBRARY }
+                .map { library ->
+                    return new ArtifactInfo(
+                            library.mavenLibrary.groupId,
+                            library.mavenLibrary.artifactId,
+                            library.mavenLibrary.version
+                    )
                 }
-            }
-            return artifacts.isEmpty()
-        } catch (JsonException exception) {
-            return false
-        }
-    }
-
-    protected void updateDependencyArtifacts() {
-        for (Configuration configuration : project.getConfigurations()) {
-            Set<ResolvedArtifact> artifacts = getResolvedArtifacts(
-                    configuration)
-            if (artifacts == null) {
-                continue
-            }
-
-            addArtifacts(artifacts)
-        }
-    }
-
-    protected addArtifacts(Set<ResolvedArtifact> artifacts) {
-        for (ResolvedArtifact artifact : artifacts) {
-            String group = artifact.moduleVersion.id.group
-            String artifact_key = artifact.file.getAbsolutePath()
-
-            if (artifactSet.contains(artifact_key)) {
-                continue
-            }
-
-            artifactSet.add(artifact_key)
-            artifactInfos.add(new ArtifactInfo(group, artifact.name,
-                    artifact.file.getAbsolutePath(),
-                    artifact.moduleVersion.id.version))
-        }
-    }
-
-    /**
-     * Checks if the configuration can be resolved. isCanBeResolved is added to
-     * gradle Api since 3.3. For the previous version, all the configurations
-     * can be resolved.
-     * @param configuration
-     * @return true if configuration can be resolved or the api is lower than
-     * 3.3, otherwise false.
-     */
-    protected boolean canBeResolved(Configuration configuration) {
-        return configuration.metaClass.respondsTo(configuration,
-                "isCanBeResolved") ? configuration.isCanBeResolved() : true
-    }
-
-    /**
-     * Checks if the configuration is from test.
-     * @param configuration
-     * @return true if configuration is a test configuration or its parent
-     * configurations are either testCompile or androidTestCompile, otherwise
-     * false.
-     */
-    protected boolean isTest(Configuration configuration) {
-        boolean isTestConfiguration = (
-                configuration.name.startsWith(TEST_PREFIX) ||
-                        configuration.name.startsWith(ANDROID_TEST_PREFIX))
-        configuration.hierarchy.each {
-            isTestConfiguration |= TEST_COMPILE.contains(it.name)
-        }
-        return isTestConfiguration
-    }
-
-    /**
-     * Checks if the configuration is for a packaged dependency (rather than e.g. a build or test time dependency)
-     * @param configuration
-     * @return true if the configuration is in the set of @link #BINARY_DEPENDENCIES
-     */
-    protected boolean isPackagedDependency(Configuration configuration) {
-        boolean isPackagedDependency = PACKAGED_DEPENDENCIES_PREFIXES.any {
-            configuration.name.startsWith(it)
-        }
-        configuration.hierarchy.each {
-            String configurationHierarchyName = it.name
-            isPackagedDependency |= PACKAGED_DEPENDENCIES_PREFIXES.any {
-                configurationHierarchyName.startsWith(it)
-            }
-        }
-
-        return isPackagedDependency
-    }
-
-    protected Set<ResolvedArtifact> getResolvedArtifacts(
-            Configuration configuration) {
-
-        if (shouldSkipConfiguration(configuration)) {
-            return null
-        }
-
-        try {
-            return getResolvedArtifactsFromResolvedDependencies(
-                    configuration.getResolvedConfiguration()
-                            .getLenientConfiguration()
-                            .getFirstLevelModuleDependencies())
-        } catch (ResolveException exception) {
-            logger.warn("Failed to resolve OSS licenses for $configuration.name.", exception)
-            return null
-        }
-    }
-
-    /**
-     * Returns true for configurations that cannot be resolved in the newer
-     * version of gradle API, are tests, or are not packaged dependencies.
-     */
-    private boolean shouldSkipConfiguration(Configuration configuration) {
-        (!canBeResolved(configuration)
-                || isTest(configuration)
-                || !isPackagedDependency(configuration))
-    }
-
-    protected Set<ResolvedArtifact> getResolvedArtifactsFromResolvedDependencies(
-            Set<ResolvedDependency> resolvedDependencies) {
-
-        HashSet<ResolvedArtifact> resolvedArtifacts = new HashSet<>()
-        for (resolvedDependency in resolvedDependencies) {
-            try {
-                if (resolvedDependency.getModuleVersion() == LOCAL_LIBRARY_VERSION) {
-                    /**
-                     * Attempting to getAllModuleArtifacts on a local library project will result
-                     * in AmbiguousVariantSelectionException as there are not enough criteria
-                     * to match a specific variant of the library project. Instead we skip the
-                     * the library project itself and enumerate its dependencies.
-                     */
-                    resolvedArtifacts.addAll(
-                            getResolvedArtifactsFromResolvedDependencies(
-                                    resolvedDependency.getChildren()))
-                } else {
-                    resolvedArtifacts.addAll(resolvedDependency.getAllModuleArtifacts())
-                }
-            } catch (AmbiguousVariantSelectionException exception) {
-                logger.warn("Failed to process $resolvedDependency.name", exception)
-            }
-        }
-        return resolvedArtifacts
+                .collect(Collectors.toUnmodifiableSet())
     }
 
     private void initOutput() {
         if (!outputDir.exists()) {
             outputDir.mkdirs()
         }
-    }
-
-    void setProject(Project project) {
-        this.project = project
     }
 }

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyUtil.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyUtil.groovy
@@ -1,0 +1,223 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gms.oss.licenses.plugin
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.artifacts.ResolvedDependency
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.result.ResolvedArtifactResult
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.internal.component.AmbiguousVariantSelectionException
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.maven.MavenModule
+import org.gradle.maven.MavenPomArtifact
+import org.slf4j.LoggerFactory
+
+/**
+ * Collection of shared utility methods and constants for dependency resolution.
+ */
+class DependencyUtil {
+    /**
+     * An artifact that represents the absence of an APG dependency list.
+     */
+    protected static final ArtifactInfo ABSENT_ARTIFACT =
+            new ArtifactInfo("absent", "absent", "absent")
+
+    protected static final String LOCAL_LIBRARY_VERSION = "unspecified"
+    private static final String TEST_PREFIX = "test"
+    private static final String ANDROID_TEST_PREFIX = "androidTest"
+    private static final Set<String> TEST_COMPILE = ["testCompile",
+                                                     "androidTestCompile"]
+
+    private static final Set<String> PACKAGED_DEPENDENCIES_PREFIXES = ["compile",
+                                                                       "implementation",
+                                                                       "api"]
+
+    private static final logger = LoggerFactory.getLogger(DependencyTask.class)
+
+
+    /**
+     * Returns the POM file associated with the supplied artifactInfo.
+     */
+    static File resolvePomFileArtifact(Project project, ArtifactInfo artifactInfo) {
+        def moduleComponentIdentifier =
+                createModuleComponentIdentifier(artifactInfo)
+        logger.info("Resolving POM file for $moduleComponentIdentifier licenses.")
+        def components = project.getDependencies()
+                .createArtifactResolutionQuery()
+                .forComponents(moduleComponentIdentifier)
+                .withArtifacts(MavenModule.class, MavenPomArtifact.class)
+                .execute()
+        if (components.resolvedComponents.isEmpty()) {
+            logger.warn("$moduleComponentIdentifier has no POM file.")
+            return null
+        }
+
+        def artifacts = components.resolvedComponents[0].getArtifacts(MavenPomArtifact.class)
+        if (artifacts.isEmpty()) {
+            logger.error("$moduleComponentIdentifier empty POM artifact list.")
+            return null
+        }
+        if (!(artifacts[0] instanceof ResolvedArtifactResult)) {
+            logger.error("$moduleComponentIdentifier unexpected type ${artifacts[0].class}")
+            return null
+        }
+        return ((ResolvedArtifactResult) artifacts[0]).getFile()
+    }
+
+    private static ModuleComponentIdentifier createModuleComponentIdentifier(ArtifactInfo artifactInfo) {
+        return new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(artifactInfo.group, artifactInfo.name), artifactInfo.version)
+    }
+
+    /**
+     * Returns the library file of a resolved dependency matching artifactInfo
+     * or null. Eagerly returns the first matching instance in the first
+     * matching configuration. Skips unresolvable, unresolved, test, and
+     * non-package dependency configurations.
+     *
+     * Will not cause an unresolved configuration to be resolved.
+     */
+    static File getLibraryFile(Project project, ArtifactInfo artifactInfo) {
+        def configurationContainer = project.getConfigurations()
+        for (Configuration configuration in configurationContainer) {
+            if (shouldSkipConfiguration(configuration)) {
+                continue
+            }
+
+            if (isNotResolved(configuration)) {
+                logger.info("Configuration ${configuration.name} is not resolved, skipping.")
+                continue
+            }
+
+            def resolvedDependencies = configuration.getResolvedConfiguration().getLenientConfiguration().allModuleDependencies
+            return findLibraryFileInResolvedDependencies(resolvedDependencies, artifactInfo, Set.of())
+        }
+        logger.warn("No resolved configurations contained $artifactInfo")
+        return null
+    }
+
+    private static File findLibraryFileInResolvedDependencies(
+            Set<ResolvedDependency> resolvedDependencies,
+            ArtifactInfo artifactInfo,
+            Set<ResolvedDependency> visitedDependencies) {
+
+        for (ResolvedDependency resolvedDependency in resolvedDependencies) {
+            try {
+                if (resolvedDependency.getModuleVersion() == LOCAL_LIBRARY_VERSION) {
+                    /**
+                     * Attempting to getAllModuleArtifacts on a local library project will result
+                     * in AmbiguousVariantSelectionException as there are not enough criteria
+                     * to match a specific variant of the library project. Instead we skip the
+                     * the library project itself and enumerate its dependencies.
+                     */
+                    if (resolvedDependency in visitedDependencies) {
+                        logger.info("Dependency cycle at ${resolvedDependency.name}")
+                        continue
+                    }
+                    File childResult = findLibraryFileInResolvedDependencies(
+                            resolvedDependency.getChildren(),
+                            artifactInfo,
+                            visitedDependencies + resolvedDependency
+                    )
+                    if (childResult != null) {
+                        return childResult
+                    }
+                } else {
+                    for (resolvedArtifact in resolvedDependency.getAllModuleArtifacts()) {
+                        if (isMatchingArtifact(resolvedArtifact, artifactInfo)) {
+                            return resolvedArtifact.file
+                        }
+                    }
+                }
+            } catch (AmbiguousVariantSelectionException exception) {
+                logger.info("Failed to process ${resolvedDependency.name}", exception)
+            }
+        }
+        return null
+    }
+
+    /**
+     * Returns true for configurations that cannot be resolved in the newer
+     * version of gradle API, are tests, or are not packaged dependencies.
+     */
+    private static boolean shouldSkipConfiguration(Configuration configuration) {
+        (!canBeResolved(configuration)
+                || isTest(configuration)
+                || !isPackagedDependency(configuration))
+    }
+
+    /**
+     * Checks if the configuration can be resolved. isCanBeResolved is added to
+     * gradle Api since 3.3. For the previous version, all the configurations
+     * can be resolved.
+     * @param configuration
+     * @return true if configuration can be resolved or the api is lower than
+     * 3.3, otherwise false.
+     */
+    protected static boolean canBeResolved(Configuration configuration) {
+        return configuration.metaClass.respondsTo(configuration,
+                "isCanBeResolved") ? configuration.isCanBeResolved() : true
+    }
+
+    /**
+     * Checks if the configuration is from test.
+     * @param configuration
+     * @return true if configuration is a test configuration or its parent
+     * configurations are either testCompile or androidTestCompile, otherwise
+     * false.
+     */
+    protected static boolean isTest(Configuration configuration) {
+        boolean isTestConfiguration = (
+                configuration.name.startsWith(TEST_PREFIX) ||
+                        configuration.name.startsWith(ANDROID_TEST_PREFIX))
+        configuration.hierarchy.each {
+            isTestConfiguration |= TEST_COMPILE.contains(it.name)
+        }
+        return isTestConfiguration
+    }
+
+    /**
+     * Checks if the configuration is for a packaged dependency (rather than e.g. a build or test time dependency)
+     * @param configuration
+     * @return true if the configuration is in the set of @link #BINARY_DEPENDENCIES
+     */
+    protected static boolean isPackagedDependency(Configuration configuration) {
+        boolean isPackagedDependency = PACKAGED_DEPENDENCIES_PREFIXES.any {
+            configuration.name.startsWith(it)
+        }
+        configuration.hierarchy.each {
+            String configurationHierarchyName = it.name
+            isPackagedDependency |= PACKAGED_DEPENDENCIES_PREFIXES.any {
+                configurationHierarchyName.startsWith(it)
+            }
+        }
+
+        return isPackagedDependency
+    }
+
+    private static boolean isNotResolved(Configuration configuration) {
+        return configuration.state != Configuration.State.RESOLVED
+    }
+
+    private static boolean isMatchingArtifact(ResolvedArtifact resolvedArtifact, ArtifactInfo artifactInfo) {
+        return (resolvedArtifact.moduleVersion.id.group == artifactInfo.group
+                && resolvedArtifact.name == artifactInfo.name
+                && resolvedArtifact.moduleVersion.id.version == artifactInfo.version)
+    }
+}

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyUtil.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyUtil.groovy
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory
  */
 class DependencyUtil {
     /**
-     * An artifact that represents the absence of an APG dependency list.
+     * An artifact that represents the absence of an AGP dependency list.
      */
     protected static final ArtifactInfo ABSENT_ARTIFACT =
             new ArtifactInfo("absent", "absent", "absent")
@@ -53,7 +53,8 @@ class DependencyUtil {
 
 
     /**
-     * Returns the POM file associated with the supplied artifactInfo.
+     * Returns the POM file associated with the supplied artifactInfo or null
+     * if none was found.
      */
     static File resolvePomFileArtifact(Project project, ArtifactInfo artifactInfo) {
         def moduleComponentIdentifier =

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesCleanUpTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesCleanUpTask.groovy
@@ -25,7 +25,7 @@ import org.gradle.api.tasks.TaskAction
  */
 class LicensesCleanUpTask extends DefaultTask {
 
-    protected File dependencyFile
+    protected File dependenciesJson
 
     protected File dependencyDir
 
@@ -37,8 +37,8 @@ class LicensesCleanUpTask extends DefaultTask {
 
     @TaskAction
     void action() {
-        if (dependencyFile.exists()) {
-            dependencyFile.delete()
+        if (dependenciesJson.exists()) {
+            dependenciesJson.delete()
         }
 
         if (dependencyDir.isDirectory() && dependencyDir.list().length == 0) {

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
@@ -16,75 +16,76 @@
 
 package com.google.android.gms.oss.licenses.plugin
 
+import com.android.build.api.artifact.SingleArtifact
 import com.android.build.gradle.api.BaseVariant
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.slf4j.LoggerFactory
 
 class OssLicensesPlugin implements Plugin<Project> {
+
+    private static final logger = LoggerFactory.getLogger(DependencyTask.class)
+
     void apply(Project project) {
-        def getDependencies = project.tasks.create("getDependencies",
-                DependencyTask)
-        def dependencyOutput = new File(project.buildDir,
-            "generated/third_party_licenses")
-        def generatedJson = new File(dependencyOutput, "dependencies.json")
-        getDependencies.setProject(project)
-        getDependencies.outputDir = dependencyOutput
-        getDependencies.outputFile = generatedJson
+        def variantTolicenseTaskMap = new HashMap<String, LicensesTask>()
+        project.androidComponents {
+            onVariants(selector().all(), { variant ->
+                def baseDir = new File(project.buildDir,
+                        "generated/third_party_licenses/${variant.name}")
+                def dependenciesJson = new File(baseDir, "dependencies.json")
 
-        def resourceOutput = new File(dependencyOutput, "/res")
-        def outputDir = new File(resourceOutput, "/raw")
-        def licensesFile = new File(outputDir, "third_party_licenses")
-        def licensesMetadataFile = new File(outputDir,
-                "third_party_license_metadata")
-        def licenseTask = project.tasks.create("generateLicenses", LicensesTask)
+                def dependencyTask = project.tasks.register(
+                        "${variant.name}OssDependencyTask",
+                        DependencyTask.class) {
+                    it.outputDir = baseDir
+                    it.outputFile = dependenciesJson
+                    it.libraryDependenciesReport.set(variant.artifacts.get(SingleArtifact.METADATA_LIBRARY_DEPENDENCIES_REPORT.INSTANCE))
+                }.get()
+                logger.debug("Created task ${dependencyTask.name}")
 
-        licenseTask.dependenciesJson = generatedJson
-        licenseTask.outputDir = outputDir
-        licenseTask.licenses = licensesFile
-        licenseTask.licensesMetadata = licensesMetadataFile
+                def resourceBaseDir = new File(baseDir, "/res")
+                def rawResourceDir = new File(resourceBaseDir, "/raw")
+                def licensesFile = new File(rawResourceDir, "third_party_licenses")
+                def licensesMetadataFile = new File(rawResourceDir,
+                        "third_party_license_metadata")
 
-        licenseTask.inputs.file(generatedJson)
-        licenseTask.outputs.dir(outputDir)
-        licenseTask.outputs.files(licensesFile, licensesMetadataFile)
+                def licenseTask = project.tasks.register(
+                        "${variant.name}OssLicensesTask",
+                        LicensesTask.class) {
+                    it.dependenciesJson = dependenciesJson
+                    it.rawResourceDir = rawResourceDir
+                    it.licenses = licensesFile
+                    it.licensesMetadata = licensesMetadataFile
+                }.get()
+                licenseTask.dependsOn(dependencyTask)
+                logger.debug("Created task ${licenseTask.name}")
 
-        licenseTask.dependsOn(getDependencies)
+                variantTolicenseTaskMap[variant.name] = licenseTask
 
-        project.android.applicationVariants.all { BaseVariant variant ->
-            // This is necessary for backwards compatibility with versions of gradle that do not support
-            // this new API.
-            if (variant.hasProperty("preBuildProvider")) {
-                variant.preBuildProvider.configure { dependsOn(licenseTask) }
-            } else {
-                //noinspection GrDeprecatedAPIUsage
-                variant.preBuild.dependsOn(licenseTask)
-            }
+                def cleanupTask = project.tasks.register(
+                        "${variant.name}OssLicensesCleanUp",
+                        LicensesCleanUpTask.class) {
+                    it.dependenciesJson = dependenciesJson
+                    it.dependencyDir = baseDir
+                    it.licensesFile = licensesFile
+                    it.metadataFile = licensesMetadataFile
+                    it.licensesDir = rawResourceDir
+                }.get()
+                logger.debug("Created task ${cleanupTask.name}")
 
-            // This is necessary for backwards compatibility with versions of gradle that do not support
-            // this new API.
-            if (variant.respondsTo("registerGeneratedResFolders")) {
-                licenseTask.ext.generatedResFolders = project.files(resourceOutput).builtBy(licenseTask)
-                variant.registerGeneratedResFolders(licenseTask.generatedResFolders)
-
-                if (variant.hasProperty("mergeResourcesProvider")) {
-                    variant.mergeResourcesProvider.configure { dependsOn(licenseTask) }
-                } else {
-                    //noinspection GrDeprecatedAPIUsage
-                    variant.mergeResources.dependsOn(licenseTask)
-                }
-            } else {
-                //noinspection GrDeprecatedAPIUsage
-                variant.registerResGeneratingTask(licenseTask, resourceOutput)
-            }
+                project.tasks.findByName("clean").dependsOn(cleanupTask)
+            })
         }
 
-        def cleanupTask = project.tasks.create("licensesCleanUp",
-                LicensesCleanUpTask)
-        cleanupTask.dependencyFile = generatedJson
-        cleanupTask.dependencyDir = dependencyOutput
-        cleanupTask.licensesFile = licensesFile
-        cleanupTask.metadataFile = licensesMetadataFile
-        cleanupTask.licensesDir = outputDir
-
-        project.tasks.findByName("clean").dependsOn(cleanupTask)
+        // TODO: Switch to new Variant API when API is ready and before
+        //  BaseVariant is removed in 8.0
+        project.android.applicationVariants.all { BaseVariant variant ->
+            def licenseTask = variantTolicenseTaskMap[variant.name]
+            if (licenseTask == null) {
+                return
+            }
+            def generatedResFolder = project.files(licenseTask.rawResourceDir.parentFile).builtBy(licenseTask)
+            variant.registerGeneratedResFolders(generatedResFolder)
+        }
     }
 }

--- a/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/DependencyTaskTest.java
+++ b/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/DependencyTaskTest.java
@@ -1,66 +1,76 @@
 /**
  * Copyright 2018 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *    https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package com.google.android.gms.oss.licenses.plugin;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static com.google.common.truth.Truth.assertThat;
 
+import com.android.tools.build.libraries.metadata.AppDependencies;
+import com.android.tools.build.libraries.metadata.Library;
+import com.android.tools.build.libraries.metadata.MavenLibrary;
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Type;
+import java.util.Collection;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.DependencySet;
-import org.gradle.api.artifacts.ExternalModuleDependency;
-import org.gradle.api.artifacts.LenientConfiguration;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.api.artifacts.ResolveException;
-import org.gradle.api.artifacts.ResolvedArtifact;
-import org.gradle.api.artifacts.ResolvedConfiguration;
-import org.gradle.api.artifacts.ResolvedDependency;
-import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.testfixtures.ProjectBuilder;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link DependencyTask} */
+/**
+ * Tests for {@link DependencyTask}
+ */
 @RunWith(JUnit4.class)
 public class DependencyTaskTest {
 
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
   private Project project;
   private DependencyTask dependencyTask;
+
+  private static AppDependencies createAppDependencies(ImmutableSet<ArtifactInfo> artifactInfoSet) {
+    AppDependencies.Builder appDependenciesBuilder = AppDependencies.newBuilder();
+    for (ArtifactInfo artifactInfo : artifactInfoSet) {
+      appDependenciesBuilder.addLibrary(Library.newBuilder()
+          .setMavenLibrary(MavenLibrary.newBuilder()
+              .setGroupId(artifactInfo.getGroup())
+              .setArtifactId(artifactInfo.getName())
+              .setVersion(artifactInfo.getVersion())
+          )
+      );
+    }
+    return appDependenciesBuilder.build();
+  }
+
+  private static File writeAppDependencies(AppDependencies appDependencies, File protoFile)
+      throws IOException {
+    try (OutputStream outputStream = new FileOutputStream(protoFile)) {
+      appDependencies.writeTo(outputStream);
+    }
+    return protoFile;
+  }
 
   @Before
   public void setUp() {
@@ -69,655 +79,67 @@ public class DependencyTaskTest {
   }
 
   @Test
-  public void collectDependenciesFromConfigurations_multipleConfigs_combined() {
-    List<String> compileExpectedIds = Arrays.asList(
-        "com.example:real-dependency:1.2.3",
-        "com.example:totally-useful:4.5.6"
+  public void testAction_valuesConvertedToJson() throws Exception {
+    File outputDir = temporaryFolder.newFolder();
+    File outputJson = new File(outputDir, "test.json");
+    dependencyTask.setOutputDir(outputDir);
+    dependencyTask.setOutputFile(outputJson);
+    ImmutableSet<ArtifactInfo> expectedArtifacts = ImmutableSet.of(
+        new ArtifactInfo("org.group.id", "artifactId", "1.0.0"),
+        new ArtifactInfo("org.group.other", "other-artifact", "3.2.1")
     );
-    Configuration compileConfiguration = mockConfiguration(
-        "compile",
-        /* canBeResolved = */ true,
-        compileExpectedIds);
-    List<String> apiExpectedIds = Arrays.asList(
-        "com.example:api-thing:1.2.3",
-        "com.example:idk-rpc:4.5.6"
-    );
-    Configuration apiConfiguration = mockConfiguration(
-        "api",
-        /* canBeResolved = */ true,
-        apiExpectedIds);
-    ConfigurationContainer configurationContainer = mock(ConfigurationContainer.class);
-    when(configurationContainer.iterator())
-        .thenReturn(Arrays.asList(compileConfiguration, apiConfiguration).iterator());
-    List<String> allExpectedIds = new ArrayList<>(compileExpectedIds);
-    allExpectedIds.addAll(apiExpectedIds);
-    Collections.sort(allExpectedIds);
+    AppDependencies appDependencies = createAppDependencies(expectedArtifacts);
+    File protoFile = writeAppDependencies(appDependencies, temporaryFolder.newFile());
+    dependencyTask.getLibraryDependenciesReport().set(protoFile);
 
-    List<String> dependencies = dependencyTask
-        .collectDependenciesFromConfigurations(configurationContainer, new HashSet<>());
-    Collections.sort(dependencies);
+    dependencyTask.action();
 
-    verify(compileConfiguration, times(1)).getAllDependencies();
-    verify(apiConfiguration, times(1)).getAllDependencies();
-    assertThat(dependencies, is(allExpectedIds));
+    verifyExpectedDependencies(expectedArtifacts, outputJson);
   }
 
   @Test
-  public void collectDependenciesFromConfigurations_libraryProject_combined() {
-    List<String> libraryProjectExpectedIds = Arrays.asList(
-        "com.example:api-thing:1.2.3",
-        "com.example:idk-rpc:4.5.6"
+  public void testAction_withNonMavenDeps_nonMavenDepsIgnored() throws Exception {
+    File outputDir = temporaryFolder.newFolder();
+    File outputJson = new File(outputDir, "test.json");
+    dependencyTask.setOutputDir(outputDir);
+    dependencyTask.setOutputFile(outputJson);
+    ImmutableSet<ArtifactInfo> expectedArtifacts = ImmutableSet.of(
+        new ArtifactInfo("org.group.id", "artifactId", "1.0.0"),
+        new ArtifactInfo("org.group.other", "other-artifact", "3.2.1")
     );
-    Configuration libraryConfiguration = mockConfiguration(
-        "compile",
-        /* canBeResolved = */ true,
-        libraryProjectExpectedIds);
-    Project libraryProject = mock(Project.class);
-    ConfigurationContainer libraryConfigurationContainer = mock(ConfigurationContainer.class);
-    when(libraryConfigurationContainer.iterator())
-        .thenReturn(Collections.singletonList(libraryConfiguration).iterator());
-    when(libraryProject.getConfigurations()).thenReturn(libraryConfigurationContainer);
-    ProjectDependency libraryProjectDependency = mockDependency(
-        ProjectDependency.class, "this:is:ignored");
-    when(libraryProjectDependency.getDependencyProject()).thenReturn(libraryProject);
+    AppDependencies appDependencies = createAppDependencies(expectedArtifacts).toBuilder()
+        .addLibrary(Library.getDefaultInstance()) // There aren't any other library types supported.
+        .build();
+    File protoFile = writeAppDependencies(appDependencies, temporaryFolder.newFile());
+    dependencyTask.getLibraryDependenciesReport().set(protoFile);
 
-    List<String> compileExpectedIds = Arrays.asList(
-        "com.example:real-dependency:1.2.3",
-        "com.example:totally-useful:4.5.6"
-    );
-    DependencySet dependencySet = mockDependencySet(new HashSet<Dependency>() {{
-      add(libraryProjectDependency);
-      add(mockDependency(ExternalModuleDependency.class, compileExpectedIds.get(0)));
-      add(mockDependency(ExternalModuleDependency.class, compileExpectedIds.get(1)));
-    }});
-    Configuration compileConfiguration = mockConfiguration(
-        "compile",
-        /* canBeResolved = */ true,
-        dependencySet);
-    ConfigurationContainer configurationContainer = mock(ConfigurationContainer.class);
-    when(configurationContainer.iterator())
-        .thenReturn(Collections.singletonList(compileConfiguration).iterator());
-    List<String> allExpectedIds = new ArrayList<>(compileExpectedIds);
-    allExpectedIds.addAll(libraryProjectExpectedIds);
-    Collections.sort(allExpectedIds);
+    dependencyTask.action();
 
-    List<String> dependencies = dependencyTask
-        .collectDependenciesFromConfigurations(configurationContainer, new HashSet<>());
-    Collections.sort(dependencies);
-
-    verify(compileConfiguration, times(1)).getAllDependencies();
-    verify(libraryConfiguration, times(1)).getAllDependencies();
-    assertThat(dependencies, is(allExpectedIds));
+    verifyExpectedDependencies(expectedArtifacts, outputJson);
   }
 
   @Test
-  public void collectDependenciesFromConfigurations_libraryDependencyCycle_visitedOnce() {
-    List<String> libraryProjectExpectedIds = Arrays.asList(
-        "com.example:api-thing:1.2.3",
-        "com.example:idk-rpc:4.5.6"
-    );
-    Project libraryProject = mock(Project.class);
-    ProjectDependency libraryProjectDependency = mockDependency(
-        ProjectDependency.class, "this:is:ignored");
-    when(libraryProjectDependency.getDependencyProject()).thenReturn(libraryProject);
-    // Library project self-dependency cycle by including itself as a dependent project.
-    DependencySet libraryDependencySet = mockDependencySet(new HashSet<Dependency>() {{
-      add(libraryProjectDependency);
-      add(mockDependency(ExternalModuleDependency.class, libraryProjectExpectedIds.get(0)));
-      add(mockDependency(ExternalModuleDependency.class, libraryProjectExpectedIds.get(1)));
-    }});
-    Configuration libraryConfiguration = mockConfiguration(
-        "compile",
-        /* canBeResolved = */ true,
-        libraryDependencySet);
-    ConfigurationContainer libraryConfigurationContainer = mock(ConfigurationContainer.class);
-    when(libraryConfigurationContainer.iterator())
-        .thenAnswer(ignored -> Collections.singletonList(libraryConfiguration).iterator());
-    when(libraryProject.getConfigurations()).thenReturn(libraryConfigurationContainer);
+  public void testAction_depFileAbsent_writesAbsentDep() throws Exception {
+    File outputDir = temporaryFolder.newFolder();
+    File outputJson = new File(outputDir, "test.json");
+    dependencyTask.setOutputDir(outputDir);
+    dependencyTask.setOutputFile(outputJson);
+    ImmutableSet<ArtifactInfo> expectedArtifacts = ImmutableSet.of(DependencyUtil.ABSENT_ARTIFACT);
 
-    List<String> compileExpectedIds = Arrays.asList(
-        "com.example:real-dependency:1.2.3",
-        "com.example:totally-useful:4.5.6"
-    );
-    DependencySet dependencySet = mockDependencySet(new HashSet<Dependency>() {{
-      add(libraryProjectDependency);
-      add(mockDependency(ExternalModuleDependency.class, compileExpectedIds.get(0)));
-      add(mockDependency(ExternalModuleDependency.class, compileExpectedIds.get(1)));
-    }});
-    Configuration compileConfiguration = mockConfiguration(
-        "compile",
-        /* canBeResolved = */ true,
-        dependencySet);
-    ConfigurationContainer configurationContainer = mock(ConfigurationContainer.class);
-    when(configurationContainer.iterator())
-        .thenReturn(Collections.singletonList(compileConfiguration).iterator());
-    List<String> allExpectedIds = new ArrayList<>(compileExpectedIds);
-    allExpectedIds.addAll(libraryProjectExpectedIds);
-    Collections.sort(allExpectedIds);
+    dependencyTask.action();
 
-    List<String> dependencies = dependencyTask
-        .collectDependenciesFromConfigurations(configurationContainer, new HashSet<>());
-    Collections.sort(dependencies);
-
-    verify(compileConfiguration, times(1)).getAllDependencies();
-    verify(libraryConfiguration, times(1)).getAllDependencies();
-    verify(libraryProject, times(1)).getConfigurations();
-    assertThat(dependencies, is(allExpectedIds));
+    verifyExpectedDependencies(expectedArtifacts, outputJson);
   }
 
-  @Test
-  public void collectDependenciesFromConfigurations_appSelfCycle_visitedOnce() {
-    List<String> appExpectedIds = Arrays.asList(
-        "com.example:real-dependency:1.2.3",
-        "com.example:totally-useful:4.5.6"
-    );
-    Project appProject = mock(Project.class);
-    when(appProject.getDisplayName()).thenReturn("YOLO");
-    ProjectDependency appProjectDependency = mockDependency(
-        ProjectDependency.class, "this:is:ignored");
-    when(appProjectDependency.getDependencyProject()).thenReturn(appProject);
-    // App project self-dependency cycle by including itself as a dependent project.
-    DependencySet dependencySet = mockDependencySet(new HashSet<Dependency>() {{
-      add(appProjectDependency);
-      add(mockDependency(ExternalModuleDependency.class, appExpectedIds.get(0)));
-      add(mockDependency(ExternalModuleDependency.class, appExpectedIds.get(1)));
-    }});
-    Configuration compileConfiguration = mockConfiguration(
-        "compile",
-        /* canBeResolved = */ true,
-        dependencySet);
-    ConfigurationContainer configurationContainer = mock(ConfigurationContainer.class);
-    when(configurationContainer.iterator())
-        .thenAnswer(ignored -> Collections.singletonList(compileConfiguration).iterator());
-    when(appProject.getConfigurations()).thenReturn(configurationContainer);
-    Collections.sort(appExpectedIds);
-
-    List<String> dependencies = dependencyTask.collectDependenciesFromConfigurations(
-        configurationContainer,
-        Collections.singleton(appProject)
-    );
-    Collections.sort(dependencies);
-
-    verify(compileConfiguration, times(1)).getAllDependencies();
-    verify(appProject, never()).getConfigurations();
-    assertThat(dependencies, is(appExpectedIds));
-  }
-
-  @Test
-  public void collectDependenciesFromConfigurations_withTestConfig_ignored() {
-    List<String> expectedIds = Arrays.asList(
-        "com.example:real-dependency:1.2.3",
-        "com.example:totally-useful:4.5.6"
-    );
-    Configuration compileConfiguration = mockConfiguration(
-        "compile",
-        /* canBeResolved = */ true,
-        expectedIds);
-    List<String> unexpectedIds = Arrays.asList(
-        "com.test-only:test-thing:1.2.3",
-        "com.test-only:not-shipped:4.5.6"
-    );
-    Configuration testConfiguration = mockConfiguration(
-        "testCompile",
-        /* canBeResolved = */ true,
-        unexpectedIds);
-    ConfigurationContainer configurationContainer = mock(ConfigurationContainer.class);
-    when(configurationContainer.iterator())
-        .thenReturn(Arrays.asList(compileConfiguration, testConfiguration).iterator());
-
-    List<String> dependencies = dependencyTask
-        .collectDependenciesFromConfigurations(configurationContainer, new HashSet<>());
-    Collections.sort(dependencies);
-
-    verify(compileConfiguration, times(1)).getAllDependencies();
-    verify(testConfiguration, never()).getAllDependencies();
-    assertThat(dependencies, is(expectedIds));
-  }
-
-  @Test
-  public void collectDependenciesFromConfigurations_withUnresolvableConfig_ignored() {
-    List<String> expectedIds = Arrays.asList(
-        "com.example:real-dependency:1.2.3",
-        "com.example:totally-useful:4.5.6"
-    );
-    Configuration compileConfiguration = mockConfiguration(
-        "compile",
-        /* canBeResolved = */ true,
-        expectedIds);
-    List<String> unexpectedIds = Arrays.asList(
-        "com.mystery:unresolvable:1.2.3",
-        "com.enigma:dont-resolve-this:4.5.6"
-    );
-    Configuration unresolvableConfiguration = mockConfiguration(
-        "api",
-        /* canBeResolved = */ false,
-        unexpectedIds);
-    ConfigurationContainer configurationContainer = mock(ConfigurationContainer.class);
-    when(configurationContainer.iterator())
-        .thenReturn(Arrays.asList(compileConfiguration, unresolvableConfiguration).iterator());
-
-    List<String> dependencies = dependencyTask
-        .collectDependenciesFromConfigurations(configurationContainer, new HashSet<>());
-    Collections.sort(dependencies);
-
-    verify(compileConfiguration, times(1)).getAllDependencies();
-    verify(unresolvableConfiguration, never()).getAllDependencies();
-    assertThat(dependencies, is(expectedIds));
-  }
-
-  @Test
-  public void collectDependenciesFromConfigurations_unusableDependencyClass_ignored() {
-    List<String> expectedIds = Collections.singletonList("should.be:alone:4.5.6");
-    DependencySet dependencySet = mockDependencySet(new HashSet<Dependency>() {{
-      add(mockDependency(Dependency.class, "should.be:skipped:1.2.3"));
-      add(mockDependency(ExternalModuleDependency.class, expectedIds.get(0)));
-    }});
-    Configuration configuration = mockConfiguration(
-        "compile",
-        /* canBeResolved = */ true,
-        dependencySet);
-    ConfigurationContainer configurationContainer = mock(ConfigurationContainer.class);
-    when(configurationContainer.iterator())
-        .thenReturn(Collections.singletonList(configuration).iterator());
-
-    List<String> dependencies = dependencyTask
-        .collectDependenciesFromConfigurations(configurationContainer, new HashSet<>());
-    Collections.sort(dependencies);
-
-    verify(configuration, times(1)).getAllDependencies();
-    assertThat(dependencies, is(expectedIds));
-  }
-
-  private Configuration mockConfiguration(String name, boolean canBeResolved,
-      List<String> mavenIds) {
-    DependencySet dependencies = mockDependencySet(mavenIds);
-    return mockConfiguration(name, canBeResolved, dependencies);
-  }
-
-  private Configuration mockConfiguration(String name, boolean canBeResolved,
-      DependencySet dependencies) {
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.getName()).thenReturn(name);
-    when(configuration.isCanBeResolved()).thenReturn(canBeResolved);
-    when(configuration.getAllDependencies()).thenReturn(dependencies);
-    return configuration;
-  }
-
-  private DependencySet mockDependencySet(List<String> mavenIds) {
-    Set<Dependency> dependencies = new HashSet<>();
-    for (String mavenId : mavenIds) {
-      dependencies.add(mockDependency(ExternalModuleDependency.class, mavenId));
+  private void verifyExpectedDependencies(ImmutableSet<ArtifactInfo> expectedArtifacts,
+      File outputJson) throws Exception {
+    Gson gson = new Gson();
+    try (FileReader reader = new FileReader(outputJson)) {
+      Type collectionOfArtifactInfo = new TypeToken<Collection<ArtifactInfo>>() {
+      }.getType();
+      Collection<ArtifactInfo> jsonArtifacts = gson.fromJson(reader, collectionOfArtifactInfo);
+      assertThat(jsonArtifacts).containsExactlyElementsIn(expectedArtifacts);
     }
-    return mockDependencySet(dependencies);
   }
 
-  private DependencySet mockDependencySet(Set<Dependency> dependencies) {
-    DependencySet dependencySet = mock(DependencySet.class);
-    when(dependencySet.iterator()).thenAnswer(ignored -> dependencies.iterator());
-    return dependencySet;
-  }
-
-  private <T extends Dependency> T mockDependency(
-      Class<T> dependencyClass,
-      String mavenId
-  ) {
-    T dependency = mock(dependencyClass);
-    String[] mavenIdFields = mavenId.split(":");
-    when(dependency.getGroup()).thenReturn(mavenIdFields[0]);
-    when(dependency.getName()).thenReturn(mavenIdFields[1]);
-    when(dependency.getVersion()).thenReturn(mavenIdFields[2]);
-    return dependency;
-  }
-
-  @Test
-  public void testCheckArtifactSet_missingSet() {
-    File dependencies = new File("src/test/resources", "testDependency.json");
-    String[] artifactSet =
-        new String[]{"dependencies/groupA/deps1.txt", "dependencies/groupB/abc/deps2.txt"};
-    dependencyTask.artifactSet = new HashSet<>(Arrays.asList(artifactSet));
-
-    assertFalse(dependencyTask.checkArtifactSet(dependencies));
-  }
-
-  @Test
-  public void testCheckArtifactSet_correctSet() {
-    File dependencies = new File("src/test/resources", "testDependency.json");
-    String[] artifactSet =
-        new String[] {
-          "dependencies/groupA/deps1.txt",
-          "dependencies/groupB/abc/deps2.txt",
-          "src/test/resources/dependencies/groupC/deps3.txt",
-          "src/test/resources/dependencies/groupD/deps4.txt"
-        };
-    dependencyTask.artifactSet = new HashSet<>(Arrays.asList(artifactSet));
-    assertTrue(dependencyTask.checkArtifactSet(dependencies));
-  }
-
-  @Test
-  public void testCheckArtifactSet_addMoreSet() {
-    File dependencies = new File("src/test/resources", "testDependency.json");
-    String[] artifactSet =
-        new String[] {
-          "dependencies/groupA/deps1.txt",
-          "dependencies/groupB/abc/deps2.txt",
-          "src/test/resources/dependencies/groupC/deps3.txt",
-          "src/test/resources/dependencies/groupD/deps4.txt",
-          "dependencies/groupE/deps5.txt"
-        };
-    dependencyTask.artifactSet = new HashSet<>(Arrays.asList(artifactSet));
-    assertFalse(dependencyTask.checkArtifactSet(dependencies));
-  }
-
-  @Test
-  public void testCheckArtifactSet_replaceSet() {
-    File dependencies = new File("src/test/resources", "testDependency.json");
-    String[] artifactSet =
-        new String[] {
-          "dependencies/groupA/deps1.txt",
-          "dependencies/groupB/abc/deps2.txt",
-          "src/test/resources/dependencies/groupC/deps3.txt",
-          "dependencies/groupE/deps5.txt"
-        };
-    dependencyTask.artifactSet = new HashSet<>(Arrays.asList(artifactSet));
-    assertFalse(dependencyTask.checkArtifactSet(dependencies));
-  }
-
-  @Test
-  public void testGetResolvedArtifacts_cannotResolve() {
-    Set<ResolvedArtifact> artifactSet = prepareArtifactSet(2);
-    ResolvedConfiguration resolvedConfiguration = mockResolvedConfiguration(artifactSet);
-
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.getName()).thenReturn("implementation");
-    when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
-
-    when(configuration.isCanBeResolved()).thenReturn(false);
-
-    assertThat(dependencyTask.getResolvedArtifacts(configuration), is(nullValue()));
-  }
-
-  @Test
-  public void testGetResolvedArtifacts_isTest() {
-    Set<ResolvedArtifact> artifactSet = prepareArtifactSet(2);
-    ResolvedConfiguration resolvedConfiguration = mockResolvedConfiguration(artifactSet);
-
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.isCanBeResolved()).thenReturn(true);
-    when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
-
-    when(configuration.getName()).thenReturn("testCompile");
-
-    assertThat(dependencyTask.getResolvedArtifacts(configuration), is(nullValue()));
-  }
-
-  @Test
-  public void testGetResolvedArtifacts_isNotPackaged() {
-    Set<ResolvedArtifact> artifactSet = prepareArtifactSet(2);
-    ResolvedConfiguration resolvedConfiguration = mockResolvedConfiguration(artifactSet);
-
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.isCanBeResolved()).thenReturn(true);
-    when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
-
-    when(configuration.getName()).thenReturn("random");
-
-    assertThat(dependencyTask.getResolvedArtifacts(configuration), is(nullValue()));
-  }
-
-  @Test
-  public void testGetResolvedArtifacts_isPackagedApi() {
-    Set<ResolvedArtifact> artifactSet = prepareArtifactSet(2);
-    ResolvedConfiguration resolvedConfiguration = mockResolvedConfiguration(artifactSet);
-
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.isCanBeResolved()).thenReturn(true);
-    when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
-
-    when(configuration.getName()).thenReturn("api");
-
-    assertThat(dependencyTask.getResolvedArtifacts(configuration), is(artifactSet));
-  }
-
-  @Test
-  public void testGetResolvedArtifacts_isPackagedImplementation() {
-    Set<ResolvedArtifact> artifactSet = prepareArtifactSet(2);
-    ResolvedConfiguration resolvedConfiguration = mockResolvedConfiguration(artifactSet);
-
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.isCanBeResolved()).thenReturn(true);
-    when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
-
-    when(configuration.getName()).thenReturn("implementation");
-
-    assertThat(dependencyTask.getResolvedArtifacts(configuration), is(artifactSet));
-  }
-
-  @Test
-  public void testGetResolvedArtifacts_isPackagedCompile() {
-    Set<ResolvedArtifact> artifactSet = prepareArtifactSet(2);
-    ResolvedConfiguration resolvedConfiguration = mockResolvedConfiguration(artifactSet);
-
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.isCanBeResolved()).thenReturn(true);
-    when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
-
-    when(configuration.getName()).thenReturn("compile");
-
-    assertThat(dependencyTask.getResolvedArtifacts(configuration), is(artifactSet));
-  }
-
-  @Test
-  public void testGetResolvedArtifacts_isPackagedInHierarchy() {
-    Set<ResolvedArtifact> artifactSet = prepareArtifactSet(2);
-    ResolvedConfiguration resolvedConfiguration = mockResolvedConfiguration(artifactSet);
-
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.getName()).thenReturn("random");
-    when(configuration.isCanBeResolved()).thenReturn(true);
-    when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
-
-    Configuration parent = mock(Configuration.class);
-    when(parent.getName()).thenReturn("compile");
-    Set<Configuration> hierarchy = new HashSet<>();
-    hierarchy.add(parent);
-    when(configuration.getHierarchy()).thenReturn(hierarchy);
-
-    assertThat(dependencyTask.getResolvedArtifacts(configuration), is(artifactSet));
-  }
-
-  @Test
-  public void testGetResolvedArtifacts_ResolveException() {
-    ResolvedConfiguration resolvedConfiguration = mock(ResolvedConfiguration.class);
-    when(resolvedConfiguration.getLenientConfiguration()).thenThrow(ResolveException.class);
-
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.getName()).thenReturn("compile");
-    when(configuration.isCanBeResolved()).thenReturn(true);
-    when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
-
-    assertThat(dependencyTask.getResolvedArtifacts(configuration), is(nullValue()));
-  }
-
-  @Test
-  public void testGetResolvedArtifacts_returnArtifact() {
-    Set<ResolvedArtifact> artifactSet = prepareArtifactSet(2);
-    ResolvedConfiguration resolvedConfiguration = mockResolvedConfiguration(artifactSet);
-
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.getName()).thenReturn("compile");
-    when(configuration.isCanBeResolved()).thenReturn(true);
-    when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
-
-    assertThat(dependencyTask.getResolvedArtifacts(configuration), is(artifactSet));
-  }
-
-  @Test
-  public void testGetResolvedArtifacts_libraryProject_returnsArtifacts() {
-    ResolvedDependency libraryResolvedDependency = mock(ResolvedDependency.class);
-    when(libraryResolvedDependency.getModuleVersion())
-            .thenReturn(DependencyTask.LOCAL_LIBRARY_VERSION);
-    ResolvedDependency libraryChildResolvedDependency = mock(ResolvedDependency.class);
-    Set<ResolvedArtifact> libraryChildArtifactSet =
-            prepareArtifactSet(/* start= */ 0, /* count= */ 2);
-    when(libraryChildResolvedDependency.getAllModuleArtifacts())
-            .thenReturn(libraryChildArtifactSet);
-    when(libraryResolvedDependency.getChildren())
-            .thenReturn(Collections.singleton(libraryChildResolvedDependency));
-
-    Set<ResolvedArtifact> appArtifactSet = prepareArtifactSet(/* start= */ 2, /* count= */ 2);
-    ResolvedDependency appResolvedDependency = mock(ResolvedDependency.class);
-    when(appResolvedDependency.getAllModuleArtifacts()).thenReturn(appArtifactSet);
-
-    Set<ResolvedDependency> resolvedDependencySet = new HashSet<>(
-            Arrays.asList(libraryResolvedDependency, appResolvedDependency));
-    ResolvedConfiguration resolvedConfiguration = mockResolvedConfigurationFromDependencySet(
-            resolvedDependencySet);
-
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.getName()).thenReturn("compile");
-    when(configuration.isCanBeResolved()).thenReturn(true);
-    when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
-
-    Set<ResolvedArtifact> artifactSuperSet = new HashSet<>();
-    artifactSuperSet.addAll(appArtifactSet);
-    artifactSuperSet.addAll(libraryChildArtifactSet);
-    assertThat(dependencyTask.getResolvedArtifacts(configuration), is(artifactSuperSet));
-    // Calling getAllModuleArtifacts on a library will cause an exception.
-    verify(libraryResolvedDependency, never()).getAllModuleArtifacts();
-  }
-
-  @NotNull
-  private ResolvedConfiguration mockResolvedConfiguration(Set<ResolvedArtifact> artifactSet) {
-    ResolvedDependency resolvedDependency = mock(ResolvedDependency.class);
-    when(resolvedDependency.getAllModuleArtifacts()).thenReturn(artifactSet);
-    Set<ResolvedDependency> resolvedDependencySet = Collections.singleton(resolvedDependency);
-    return mockResolvedConfigurationFromDependencySet(resolvedDependencySet);
-  }
-
-  @NotNull
-  private ResolvedConfiguration mockResolvedConfigurationFromDependencySet(
-          Set<ResolvedDependency> resolvedDependencySet) {
-
-    LenientConfiguration lenientConfiguration = mock(LenientConfiguration.class);
-    when(lenientConfiguration.getFirstLevelModuleDependencies()).thenReturn(resolvedDependencySet);
-    ResolvedConfiguration resolvedConfiguration = mock(ResolvedConfiguration.class);
-    when(resolvedConfiguration.getLenientConfiguration()).thenReturn(lenientConfiguration);
-    return resolvedConfiguration;
-  }
-
-  @Test
-  public void testAddArtifacts() {
-    Set<ResolvedArtifact> artifacts = prepareArtifactSet(3);
-
-    dependencyTask.addArtifacts(artifacts);
-    assertThat(dependencyTask.artifactInfos.size(), is(3));
-  }
-
-  @Test
-  public void testAddArtifacts_willNotAddDuplicate() {
-    Set<ResolvedArtifact> artifacts = prepareArtifactSet(2);
-
-    String[] keySets = new String[] {"location1", "location2"};
-    dependencyTask.artifactSet = new HashSet<>(Arrays.asList(keySets));
-    dependencyTask.addArtifacts(artifacts);
-
-    assertThat(dependencyTask.artifactInfos.size(), is(1));
-  }
-
-  @Test
-  public void testCanBeResolved_isTrue() {
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.isCanBeResolved()).thenReturn(true);
-
-    assertTrue(dependencyTask.canBeResolved(configuration));
-  }
-
-  @Test
-  public void testCanBeResolved_isFalse() {
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.isCanBeResolved()).thenReturn(false);
-
-    assertFalse(dependencyTask.canBeResolved(configuration));
-  }
-
-  @Test
-  public void testIsTest_isNotTest() {
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.getName()).thenReturn("random");
-
-    assertFalse(dependencyTask.isTest(configuration));
-  }
-
-  @Test
-  public void testIsTest_isTestCompile() {
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.getName()).thenReturn("testCompile");
-
-    assertTrue(dependencyTask.isTest(configuration));
-  }
-
-  @Test
-  public void testIsTest_isAndroidTestCompile() {
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.getName()).thenReturn("androidTestCompile");
-
-    assertTrue(dependencyTask.isTest(configuration));
-  }
-
-  @Test
-  public void testIsTest_fromHierarchy() {
-    Configuration configuration = mock(Configuration.class);
-    when(configuration.getName()).thenReturn("random");
-
-    Configuration parent = mock(Configuration.class);
-    when(parent.getName()).thenReturn("testCompile");
-
-    Set<Configuration> hierarchy = new HashSet<>();
-    hierarchy.add(parent);
-
-    when(configuration.getHierarchy()).thenReturn(hierarchy);
-    assertTrue(dependencyTask.isTest(configuration));
-  }
-
-  private Set<ResolvedArtifact> prepareArtifactSet(int count) {
-    return prepareArtifactSet(0, count);
-  }
-
-  private Set<ResolvedArtifact> prepareArtifactSet(int start, int count) {
-    Set<ResolvedArtifact> artifacts = new HashSet<>();
-    String namePrefix = "artifact";
-    String groupPrefix = "group";
-    String locationPrefix = "location";
-    String versionPostfix = ".0";
-    for (int i = start; i < start + count; i++) {
-      String index = String.valueOf(i);
-      artifacts.add(
-          prepareArtifact(
-              namePrefix + index,
-              groupPrefix + index,
-              locationPrefix + index,
-              index + versionPostfix));
-    }
-    return artifacts;
-  }
-
-  private ResolvedArtifact prepareArtifact(
-      String name, String group, String filePath, String version) {
-    ModuleVersionIdentifier moduleId = mock(ModuleVersionIdentifier.class);
-    when(moduleId.getGroup()).thenReturn(group);
-    when(moduleId.getVersion()).thenReturn(version);
-
-    ResolvedModuleVersion moduleVersion = mock(ResolvedModuleVersion.class);
-    when(moduleVersion.getId()).thenReturn(moduleId);
-
-    File artifactFile = mock(File.class);
-    when(artifactFile.getAbsolutePath()).thenReturn(filePath);
-
-    ResolvedArtifact artifact = mock(ResolvedArtifact.class);
-    when(artifact.getName()).thenReturn(name);
-    when(artifact.getFile()).thenReturn(artifactFile);
-    when(artifact.getModuleVersion()).thenReturn(moduleVersion);
-
-    return artifact;
-  }
 }

--- a/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/DependencyUtilTest.java
+++ b/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/DependencyUtilTest.java
@@ -1,0 +1,390 @@
+package com.google.android.gms.oss.licenses.plugin;
+
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Configuration.State;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.LenientConfiguration;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.ResolvedConfiguration;
+import org.gradle.api.artifacts.ResolvedDependency;
+import org.gradle.api.artifacts.ResolvedModuleVersion;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class DependencyUtilTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void getLibraryFile_returnsLibraryFile() throws Exception {
+    ArtifactInfo artifactInfo = new ArtifactInfo("com.google.android.gms.test", "test", "1.0.0");
+    File expectedFile = temporaryFolder.newFile();
+    ResolvedArtifact resolvedArtifact = mockResolvedArtifact(artifactInfo, expectedFile);
+    Configuration compileConfiguration = mockConfiguration(
+        "compile",
+        /* canBeResolved = */ true,
+        State.RESOLVED,
+        mockSingleDependencySet(resolvedArtifact));
+    Project project = mockProjectWithConfiguration(compileConfiguration);
+
+    File libraryFile = DependencyUtil.getLibraryFile(project, artifactInfo);
+
+    assertThat(libraryFile).isEqualTo(expectedFile);
+  }
+
+  @Test
+  public void getLibraryFile_noVersionMatch_returnsNull() throws Exception {
+    ArtifactInfo artifactInfo = new ArtifactInfo("com.google.android.gms.test", "test", "1.0.0");
+    File expectedFile = temporaryFolder.newFile();
+    ResolvedArtifact resolvedArtifact = mockResolvedArtifact(artifactInfo, expectedFile);
+    Configuration compileConfiguration = mockConfiguration(
+        "compile",
+        /* canBeResolved = */ true,
+        State.RESOLVED,
+        mockSingleDependencySet(resolvedArtifact));
+    Project project = mockProjectWithConfiguration(compileConfiguration);
+    ArtifactInfo differentVersionInfo = new ArtifactInfo("com.google.android.gms.test", "test",
+        "2.0.0");
+
+    File libraryFile = DependencyUtil.getLibraryFile(project, differentVersionInfo);
+
+    assertThat(libraryFile).isNull();
+  }
+
+  @Test
+  public void getLibraryFile_noMatch_returnsNull() throws Exception {
+    ArtifactInfo artifactInfo = new ArtifactInfo("com.google.android.gms.test", "test", "1.0.0");
+    File expectedFile = temporaryFolder.newFile();
+    ResolvedArtifact resolvedArtifact = mockResolvedArtifact(artifactInfo, expectedFile);
+    Configuration compileConfiguration = mockConfiguration(
+        "compile",
+        /* canBeResolved = */ true,
+        State.RESOLVED,
+        mockSingleDependencySet(resolvedArtifact));
+    Project project = mockProjectWithConfiguration(compileConfiguration);
+    ArtifactInfo missingArtifactInfo = new ArtifactInfo("com.uhoh.example", "whoops", "1.0.0");
+
+    File libraryFile = DependencyUtil.getLibraryFile(project, missingArtifactInfo);
+
+    assertThat(libraryFile).isNull();
+  }
+
+  @Test
+  public void getLibraryFile_unresolvedConfiguration_returnsNull() throws Exception {
+    ArtifactInfo artifactInfo = new ArtifactInfo("com.google.android.gms.test", "test", "1.0.0");
+    File expectedFile = temporaryFolder.newFile();
+    ResolvedArtifact resolvedArtifact = mockResolvedArtifact(artifactInfo, expectedFile);
+    Configuration compileConfiguration = mockConfiguration(
+        "compile",
+        /* canBeResolved = */ true,
+        State.UNRESOLVED,
+        mockSingleDependencySet(resolvedArtifact));
+    Project project = mockProjectWithConfiguration(compileConfiguration);
+
+    File libraryFile = DependencyUtil.getLibraryFile(project, artifactInfo);
+
+    assertThat(libraryFile).isNull();
+    verify(compileConfiguration, never()).getResolvedConfiguration();
+  }
+
+  @Test
+  public void getLibraryFile_withUnwantedConfigs_skipsUnwantedConfigs() throws Exception {
+    ArtifactInfo artifactInfo = new ArtifactInfo("com.google.android.gms.test", "test", "1.0.0");
+    File expectedFile = temporaryFolder.newFile();
+    ResolvedArtifact resolvedArtifact = mockResolvedArtifact(artifactInfo, expectedFile);
+    Configuration compileConfiguration = mockConfiguration(
+        "compile",
+        /* canBeResolved = */ true,
+        State.RESOLVED,
+        mockSingleDependencySet(resolvedArtifact));
+    Configuration arbitraryConfiguration = mockConfiguration(
+        "arbitrary",
+        /* canBeResolved = */ true,
+        State.RESOLVED,
+        mockSingleDependencySet(resolvedArtifact));
+    Configuration testConfiguration = mockConfiguration(
+        "androidTest",
+        /* canBeResolved = */ true,
+        State.RESOLVED,
+        mockSingleDependencySet(resolvedArtifact));
+    Configuration unresolvableConfiguration = mockConfiguration(
+        "api",
+        /* canBeResolved = */ false,
+        State.UNRESOLVED,
+        mockSingleDependencySet(resolvedArtifact));
+    Project project = mockProjectWithConfigurations(ImmutableSet.of(
+        compileConfiguration,
+        arbitraryConfiguration,
+        testConfiguration,
+        unresolvableConfiguration)
+    );
+
+    File libraryFile = DependencyUtil.getLibraryFile(project, artifactInfo);
+
+    assertThat(libraryFile).isEqualTo(expectedFile);
+    verify(compileConfiguration, times(1)).getResolvedConfiguration();
+    verify(arbitraryConfiguration, never()).getResolvedConfiguration();
+    verify(testConfiguration, never()).getResolvedConfiguration();
+    verify(unresolvableConfiguration, never()).getResolvedConfiguration();
+  }
+
+  @Test
+  public void getLibraryFile_withLibraryDependency_readsChildrenOfLibrary() throws Exception {
+    ArtifactInfo artifactInfo = new ArtifactInfo("com.google.android.gms.test", "test", "1.0.0");
+    File expectedFile = temporaryFolder.newFile();
+    ResolvedArtifact resolvedArtifact = mockResolvedArtifact(artifactInfo, expectedFile);
+
+    ResolvedDependency libraryDependency = mock(ResolvedDependency.class);
+    when(libraryDependency.getModuleVersion()).thenReturn(DependencyUtil.LOCAL_LIBRARY_VERSION);
+    ImmutableSet<ResolvedDependency> children = mockSingleDependencySet(resolvedArtifact);
+    when(libraryDependency.getChildren()).thenReturn(children);
+
+    Configuration compileConfiguration = mockConfiguration(
+        "compile",
+        /* canBeResolved = */ true,
+        State.RESOLVED,
+        ImmutableSet.of(libraryDependency));
+    Project project = mockProjectWithConfiguration(compileConfiguration);
+
+    File libraryFile = DependencyUtil.getLibraryFile(project, artifactInfo);
+
+    assertThat(libraryFile).isEqualTo(expectedFile);
+    verify(libraryDependency, never()).getAllModuleArtifacts();
+  }
+
+  @Test
+  public void getLibraryFile_withLibraryDependencyCycle_readsChildrenOfLibrary() throws Exception {
+    ArtifactInfo artifactInfo = new ArtifactInfo("com.google.android.gms.test", "test", "1.0.0");
+    File expectedFile = temporaryFolder.newFile();
+    ResolvedArtifact resolvedArtifact = mockResolvedArtifact(artifactInfo, expectedFile);
+
+    ResolvedDependency libraryDependency = mock(ResolvedDependency.class);
+    ResolvedDependency childLibraryDependency = mock(ResolvedDependency.class);
+    when(libraryDependency.getModuleVersion()).thenReturn(DependencyUtil.LOCAL_LIBRARY_VERSION);
+    when(libraryDependency.getChildren()).thenReturn(ImmutableSet.of(childLibraryDependency));
+    when(childLibraryDependency.getModuleVersion()).thenReturn(
+        DependencyUtil.LOCAL_LIBRARY_VERSION);
+    ImmutableSet<ResolvedDependency> grandChildren = ImmutableSet.of(
+        libraryDependency, // <- Two hop dependency cycle to parent
+        mockResolvedDependency(ImmutableSet.of(resolvedArtifact))
+    );
+    when(childLibraryDependency.getChildren()).thenReturn(grandChildren);
+
+    Configuration compileConfiguration = mockConfiguration(
+        "compile",
+        /* canBeResolved = */ true,
+        State.RESOLVED,
+        ImmutableSet.of(libraryDependency));
+    Project project = mockProjectWithConfiguration(compileConfiguration);
+
+    File libraryFile = DependencyUtil.getLibraryFile(project, artifactInfo);
+
+    assertThat(libraryFile).isEqualTo(expectedFile);
+    verify(libraryDependency, never()).getAllModuleArtifacts();
+  }
+
+  @Test
+  public void getLibraryFile_withStubLibraryDependency_readsFromMainConfig() throws Exception {
+    ArtifactInfo artifactInfo = new ArtifactInfo("com.google.android.gms.test", "test", "1.0.0");
+    File expectedFile = temporaryFolder.newFile();
+    ResolvedArtifact resolvedArtifact = mockResolvedArtifact(artifactInfo, expectedFile);
+
+    ResolvedDependency libraryDependency = mock(ResolvedDependency.class);
+    when(libraryDependency.getModuleVersion()).thenReturn(DependencyUtil.LOCAL_LIBRARY_VERSION);
+    ImmutableSet<ResolvedDependency> children = ImmutableSet.of();
+    when(libraryDependency.getChildren()).thenReturn(children);
+
+    Configuration compileConfiguration = mockConfiguration(
+        "compile",
+        /* canBeResolved = */ true,
+        State.RESOLVED,
+        ImmutableSet.of(
+            libraryDependency, mockResolvedDependency(ImmutableSet.of(resolvedArtifact))
+        ));
+    Project project = mockProjectWithConfiguration(compileConfiguration);
+
+    File libraryFile = DependencyUtil.getLibraryFile(project, artifactInfo);
+
+    assertThat(libraryFile).isEqualTo(expectedFile);
+    verify(libraryDependency, never()).getAllModuleArtifacts();
+  }
+
+  private Configuration mockConfiguration(String name, boolean canBeResolved,
+      Configuration.State state, ImmutableSet<ResolvedDependency> resolvedDependencies) {
+    Configuration configuration = mock(Configuration.class);
+    when(configuration.getName()).thenReturn(name);
+    when(configuration.getState()).thenReturn(state);
+    when(configuration.isCanBeResolved()).thenReturn(canBeResolved);
+
+    ResolvedConfiguration resolvedConfiguration = mock(ResolvedConfiguration.class);
+    when(configuration.getResolvedConfiguration()).thenReturn(resolvedConfiguration);
+    LenientConfiguration lenientConfiguration = mock(LenientConfiguration.class);
+    when(lenientConfiguration.getAllModuleDependencies()).thenReturn(resolvedDependencies);
+    when(resolvedConfiguration.getLenientConfiguration()).thenReturn(lenientConfiguration);
+
+    return configuration;
+  }
+
+  private ImmutableSet<ResolvedDependency> mockSingleDependencySet(
+      ResolvedArtifact resolvedArtifact) {
+    return ImmutableSet.of(mockResolvedDependency(ImmutableSet.of(resolvedArtifact)));
+  }
+
+  private ResolvedDependency mockResolvedDependency(
+      ImmutableSet<ResolvedArtifact> resolvedArtifacts) {
+    ResolvedDependency resolvedDependency = mock(ResolvedDependency.class);
+    when(resolvedDependency.getAllModuleArtifacts()).thenReturn(resolvedArtifacts);
+    return resolvedDependency;
+  }
+
+  private Project mockProjectWithConfiguration(Configuration configuration) {
+    return mockProjectWithConfigurations(ImmutableSet.of(configuration));
+  }
+
+  private Project mockProjectWithConfigurations(ImmutableSet<Configuration> configurations) {
+    ConfigurationContainer configurationContainer = mock(ConfigurationContainer.class);
+    when(configurationContainer.iterator())
+        .thenReturn(configurations.iterator());
+
+    Project project = mock(Project.class);
+    when(project.getConfigurations()).thenReturn(configurationContainer);
+    return project;
+  }
+
+  private ResolvedArtifact mockResolvedArtifact(ArtifactInfo artifactInfo, File artifactFile) {
+    ModuleVersionIdentifier moduleId = mock(ModuleVersionIdentifier.class);
+    when(moduleId.getGroup()).thenReturn(artifactInfo.getGroup());
+    when(moduleId.getVersion()).thenReturn(artifactInfo.getVersion());
+
+    ResolvedModuleVersion moduleVersion = mock(ResolvedModuleVersion.class);
+    when(moduleVersion.getId()).thenReturn(moduleId);
+
+    ResolvedArtifact artifact = mock(ResolvedArtifact.class);
+    when(artifact.getName()).thenReturn(artifactInfo.getName());
+    when(artifact.getFile()).thenReturn(artifactFile);
+    when(artifact.getModuleVersion()).thenReturn(moduleVersion);
+
+    return artifact;
+  }
+
+  @Test
+  public void canBeResolved_isTrue() {
+    Configuration configuration = mock(Configuration.class);
+    when(configuration.isCanBeResolved()).thenReturn(true);
+
+    assertThat(DependencyUtil.canBeResolved(configuration)).isTrue();
+  }
+
+  @Test
+  public void canBeResolved_isFalse() {
+    Configuration configuration = mock(Configuration.class);
+    when(configuration.isCanBeResolved()).thenReturn(false);
+
+    assertThat(DependencyUtil.canBeResolved(configuration)).isFalse();
+  }
+
+  @Test
+  public void isTest_arbitraryConfiguration_returnsFalse() {
+    Configuration configuration = mock(Configuration.class);
+    when(configuration.getName()).thenReturn("arbitrary");
+
+    assertThat(DependencyUtil.isTest(configuration)).isFalse();
+  }
+
+  @Test
+  public void isTest_testCompile_returnsTrue() {
+    Configuration configuration = mock(Configuration.class);
+    when(configuration.getName()).thenReturn("testCompile");
+
+    assertThat(DependencyUtil.isTest(configuration)).isTrue();
+  }
+
+  @Test
+  public void isTest_androidTestCompile_returnsTrue() {
+    Configuration configuration = mock(Configuration.class);
+    when(configuration.getName()).thenReturn("androidTestCompile");
+
+    assertThat(DependencyUtil.isTest(configuration)).isTrue();
+  }
+
+  @Test
+  public void isTest_parentIsTest_returnsTrue() {
+    Configuration configuration = mock(Configuration.class);
+    when(configuration.getName()).thenReturn("someArbitraryChildName");
+
+    Configuration parent = mock(Configuration.class);
+    when(parent.getName()).thenReturn("testCompile");
+
+    Set<Configuration> hierarchy = new HashSet<>();
+    hierarchy.add(parent);
+
+    when(configuration.getHierarchy()).thenReturn(hierarchy);
+    assertThat(DependencyUtil.isTest(configuration)).isTrue();
+  }
+
+  @Test
+  public void isPackagedDependency_arbitraryConfiguration_returnsFalse() {
+    Configuration configuration = mock(Configuration.class);
+    when(configuration.getName()).thenReturn("arbitrary");
+
+    assertThat(DependencyUtil.isPackagedDependency(configuration)).isFalse();
+  }
+
+  @Test
+  public void isPackagedDependency_apiConfiguration_returnsTrue() {
+    Configuration configuration = mock(Configuration.class);
+    when(configuration.getName()).thenReturn("api");
+
+    assertThat(DependencyUtil.isPackagedDependency(configuration)).isTrue();
+  }
+
+  @Test
+  public void isPackagedDependency_implementationConfiguration_returnsTrue() {
+    Configuration configuration = mock(Configuration.class);
+    when(configuration.getName()).thenReturn("implementation");
+
+    assertThat(DependencyUtil.isPackagedDependency(configuration)).isTrue();
+  }
+
+  @Test
+  public void isPackagedDependency_compileConfiguration_returnsTrue() {
+    Configuration configuration = mock(Configuration.class);
+    when(configuration.getName()).thenReturn("compile");
+
+    assertThat(DependencyUtil.isPackagedDependency(configuration)).isTrue();
+  }
+
+  @Test
+  public void isPackagedDependency_compileConfigurationChild_returnsTrue() {
+    Configuration configuration = mock(Configuration.class);
+    when(configuration.getName()).thenReturn("someArbitraryChildName");
+
+    Configuration parent = mock(Configuration.class);
+    when(parent.getName()).thenReturn("compile");
+    Set<Configuration> hierarchy = new HashSet<>();
+    hierarchy.add(parent);
+    when(configuration.getHierarchy()).thenReturn(hierarchy);
+
+    assertThat(DependencyUtil.isPackagedDependency(configuration)).isTrue();
+  }
+
+}

--- a/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/GoogleServicesLicenseTest.java
+++ b/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/GoogleServicesLicenseTest.java
@@ -1,68 +1,51 @@
 /**
  * Copyright 2018 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *    https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package com.google.android.gms.oss.licenses.plugin;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
 import java.util.Arrays;
-import org.gradle.api.Project;
-import org.gradle.testfixtures.ProjectBuilder;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-/** Test for {@link LicensesTask#isGoogleServices(String, String)} */
+/**
+ * Test for {@link LicensesTask#isGoogleServices(String)}
+ */
 @RunWith(Parameterized.class)
 public class GoogleServicesLicenseTest {
-  private static final String BASE_DIR = "src/test/resources";
-  private Project project;
-  private LicensesTask licensesTask;
+
+  @Parameter(0)
+  public String inputGroup;
+  @Parameter(1)
+  public Boolean expectedResult;
 
   @Parameters
   public static Iterable<Object[]> data() {
     return Arrays.asList(
-        new Object[][] {
-          {"com.google.android.gms", "play-services-foo", true},
-          {"com.google.firebase", "firebase-bar", true},
-          {"com.example", "random", false},
+        new Object[][]{
+            {"com.google.android.gms", true},
+            {"com.google.firebase", true},
+            {"com.example", false},
         });
-  }
-
-  @Parameter(0)
-  public String inputGroup;
-
-  @Parameter(1)
-  public String inputArtifactName;
-
-  @Parameter(2)
-  public Boolean expectedResult;
-
-  @Before
-  public void setUp() {
-    project = ProjectBuilder.builder().withProjectDir(new File(BASE_DIR)).build();
-    licensesTask = project.getTasks().create("generateLicenses", LicensesTask.class);
   }
 
   @Test
   public void test() {
-    assertEquals(expectedResult, licensesTask.isGoogleServices(inputGroup, inputArtifactName));
+    assertEquals(expectedResult, LicensesTask.isGoogleServices(inputGroup));
   }
 }

--- a/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/LicensesCleanUpTaskTest.java
+++ b/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/LicensesCleanUpTaskTest.java
@@ -1,17 +1,15 @@
 /**
  * Copyright 2018 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *    https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package com.google.android.gms.oss.licenses.plugin;
@@ -31,7 +29,9 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link LicensesCleanUpTask} */
 @RunWith(JUnit4.class)
 public class LicensesCleanUpTaskTest {
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
   public void testAction() throws IOException {
@@ -52,13 +52,13 @@ public class LicensesCleanUpTaskTest {
     LicensesCleanUpTask task =
         project.getTasks().create("licensesCleanUp", LicensesCleanUpTask.class);
     task.dependencyDir = dependencyDir;
-    task.dependencyFile = dependencyFile;
+    task.dependenciesJson = dependencyFile;
     task.licensesDir = licensesDir;
     task.licensesFile = licensesFile;
     task.metadataFile = metadataFile;
 
     task.action();
-    assertFalse(task.dependencyFile.exists());
+    assertFalse(task.dependenciesJson.exists());
     assertFalse(task.dependencyDir.exists());
     assertFalse(task.licensesFile.exists());
     assertFalse(task.metadataFile.exists());

--- a/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/LicensesTaskTest.java
+++ b/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/LicensesTaskTest.java
@@ -1,17 +1,15 @@
 /**
  * Copyright 2018 Google LLC
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *    https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package com.google.android.gms.oss.licenses.plugin;
@@ -27,16 +25,23 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonWriter;
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.gradle.api.Project;
+import org.gradle.internal.impldep.com.fasterxml.jackson.core.json.JsonWriteContext;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Before;
 import org.junit.Rule;
@@ -48,13 +53,14 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link LicensesTask} */
 @RunWith(JUnit4.class)
 public class LicensesTaskTest {
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  private static final Charset UTF_8 = StandardCharsets.UTF_8;
   private static final String BASE_DIR = "src/test/resources";
   private static final String LINE_BREAK = System.getProperty("line.separator");
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
   private Project project;
   private LicensesTask licensesTask;
-
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Before
   public void setUp() throws IOException {
@@ -65,30 +71,16 @@ public class LicensesTaskTest {
     project = ProjectBuilder.builder().withProjectDir(new File(BASE_DIR)).build();
     licensesTask = project.getTasks().create("generateLicenses", LicensesTask.class);
 
-    licensesTask.setOutputDir(outputDir);
+    licensesTask.setRawResourceDir(outputDir);
     licensesTask.setLicenses(outputLicenses);
     licensesTask.setLicensesMetadata(outputMetadata);
-  }
-
-  private void createLicenseZip(String name) throws IOException {
-    File zipFile = new File(name);
-    ZipOutputStream output = new ZipOutputStream(new FileOutputStream(zipFile));
-    File input = new File(BASE_DIR + "/sampleLicenses");
-    for (File file : input.listFiles()) {
-      ZipEntry entry = new ZipEntry(file.getName());
-      byte[] bytes = Files.readAllBytes(file.toPath());
-      output.putNextEntry(entry);
-      output.write(bytes, 0, bytes.length);
-      output.closeEntry();
-    }
-    output.close();
   }
 
   @Test
   public void testInitOutputDir() {
     licensesTask.initOutputDir();
 
-    assertTrue(licensesTask.getOutputDir().exists());
+    assertTrue(licensesTask.getRawResourceDir().exists());
   }
 
   @Test
@@ -110,13 +102,13 @@ public class LicensesTaskTest {
   @Test
   public void testIsGranularVersion_True() {
     String versionTrue = "14.6.0";
-    assertTrue(licensesTask.isGranularVersion(versionTrue));
+    assertTrue(LicensesTask.isGranularVersion(versionTrue));
   }
 
   @Test
   public void testIsGranularVersion_False() {
     String versionFalse = "11.4.0";
-    assertFalse(licensesTask.isGranularVersion(versionFalse));
+    assertFalse(LicensesTask.isGranularVersion(versionFalse));
   }
 
   @Test
@@ -212,7 +204,7 @@ public class LicensesTaskTest {
     InputStream inputStream = mock(InputStream.class);
     when(inputStream.read(any(byte[].class), anyInt(), anyInt())).thenThrow(new IOException());
     try {
-      licensesTask.getBytesFromInputStream(inputStream, 1, 1);
+      LicensesTask.getBytesFromInputStream(inputStream, 1, 1);
       fail("This test should throw Exception.");
     } catch (RuntimeException e) {
       assertEquals("Failed to read license text.", e.getMessage());
@@ -223,7 +215,7 @@ public class LicensesTaskTest {
   public void testGetBytesFromInputStream_normalText() {
     String test = "test";
     InputStream inputStream = new ByteArrayInputStream(test.getBytes(UTF_8));
-    String content = new String(licensesTask.getBytesFromInputStream(inputStream, 1, 1), UTF_8);
+    String content = new String(LicensesTask.getBytesFromInputStream(inputStream, 1, 1), UTF_8);
     assertEquals("e", content);
   }
 
@@ -231,13 +223,13 @@ public class LicensesTaskTest {
   public void testGetBytesFromInputStream_specialCharacters() {
     String test = "Copyright © 1991-2017 Unicode";
     InputStream inputStream = new ByteArrayInputStream(test.getBytes(UTF_8));
-    String content = new String(licensesTask.getBytesFromInputStream(inputStream, 4, 18), UTF_8);
+    String content = new String(LicensesTask.getBytesFromInputStream(inputStream, 4, 18), UTF_8);
     assertEquals("right © 1991-2017", content);
   }
 
   @Test
   public void testAddGooglePlayServiceLicenses() throws IOException {
-    File tempOutput = new File(licensesTask.getOutputDir(), "dependencies/groupC");
+    File tempOutput = new File(licensesTask.getRawResourceDir(), "dependencies/groupC");
     tempOutput.mkdirs();
     createLicenseZip(tempOutput.getPath() + "play-services-foo-license.aar");
     File artifact = new File(tempOutput.getPath() + "play-services-foo-license.aar");
@@ -256,12 +248,12 @@ public class LicensesTaskTest {
 
   @Test
   public void testAddGooglePlayServiceLicenses_withoutDuplicate() throws IOException {
-    File groupC = new File(licensesTask.getOutputDir(), "dependencies/groupC");
+    File groupC = new File(licensesTask.getRawResourceDir(), "dependencies/groupC");
     groupC.mkdirs();
     createLicenseZip(groupC.getPath() + "/play-services-foo-license.aar");
     File artifactFoo = new File(groupC.getPath() + "/play-services-foo-license.aar");
 
-    File groupD = new File(licensesTask.getOutputDir(), "dependencies/groupD");
+    File groupD = new File(licensesTask.getRawResourceDir(), "dependencies/groupD");
     groupD.mkdirs();
     createLicenseZip(groupD.getPath() + "/play-services-bar-license.aar");
     File artifactBar = new File(groupD.getPath() + "/play-services-bar-license.aar");
@@ -280,11 +272,25 @@ public class LicensesTaskTest {
     assertTrue(licensesTask.licensesMap.containsKey("JSR 305"));
   }
 
+  private void createLicenseZip(String name) throws IOException {
+    File zipFile = new File(name);
+    ZipOutputStream output = new ZipOutputStream(new FileOutputStream(zipFile));
+    File input = new File(BASE_DIR + "/sampleLicenses");
+    for (File file : input.listFiles()) {
+      ZipEntry entry = new ZipEntry(file.getName());
+      byte[] bytes = Files.readAllBytes(file.toPath());
+      output.putNextEntry(entry);
+      output.write(bytes, 0, bytes.length);
+      output.closeEntry();
+    }
+    output.close();
+  }
+
   @Test
   public void testAppendLicense() throws IOException {
     licensesTask.appendDependency(
-            new LicensesTask.Dependency("license1", "license1"),
-            "test".getBytes(UTF_8));
+        new LicensesTask.Dependency("license1", "license1"),
+        "test".getBytes(UTF_8));
 
     String expected = "test" + LINE_BREAK;
     String content = new String(Files.readAllBytes(licensesTask.getLicenses().toPath()), UTF_8);
@@ -301,7 +307,8 @@ public class LicensesTaskTest {
     licensesTask.writeMetadata();
 
     String expected = "0:4 Dependency 1" + LINE_BREAK + "6:10 Dependency 2" + LINE_BREAK;
-    String content = new String(Files.readAllBytes(licensesTask.getLicensesMetadata().toPath()), UTF_8);
+    String content = new String(Files.readAllBytes(licensesTask.getLicensesMetadata().toPath()),
+        UTF_8);
     assertEquals(expected, content);
   }
 
@@ -321,4 +328,24 @@ public class LicensesTaskTest {
     assertTrue(licensesTask.licensesMap.containsKey("groupF:deps6"));
     assertTrue(licensesTask.licensesMap.containsKey("groupF:deps7"));
   }
+
+  @Test
+  public void action_absentDependencies_rendersAbsentData() throws Exception {
+    File dependenciesJson = temporaryFolder.newFile();
+    ArtifactInfo[] artifactInfoArray = new ArtifactInfo[] { DependencyUtil.ABSENT_ARTIFACT };
+    Gson gson = new Gson();
+    try (FileWriter writer = new FileWriter(dependenciesJson)) {
+      gson.toJson(artifactInfoArray, writer);
+    }
+    licensesTask.setDependenciesJson(dependenciesJson);
+
+    licensesTask.action();
+
+    String line;
+    try (BufferedReader reader = new BufferedReader(new FileReader(licensesTask.getLicenses()))) {
+      line = reader.readLine();
+    }
+    assertEquals(line, LicensesTask.ABSENT_DEPENDENCY_TEXT);
+  }
+
 }


### PR DESCRIPTION
- Requires AGP (com.android.tools.build:gradle) 7.1.0 or higher.
- Read from AGP generated dependency protobuf if available, otherwise use placeholder for debug builds.
- Extract POM resolution into utility class.
- Locate Google Play Services artifacts by walking resolved dependencies after resolution.
- Avoid causing unresolved dependencies to be resolved.
- Clean up some potentially unclosed input streams.
- fixes #214 fixes #215 fixes #200 
  - Caused by early, recursive dependency resolution.
- fixes #202
  - Reduced logging level for these. They're unexpected, but not problematic.
- fixes #209 fixes google/dagger#2744 fixes #194 
  - Also requires updating to hilt 2.40.5 (perhaps lower) to work with AGP 7.1+.