### PR TITLE
Publish plugin marker for oss-licenses-plugin

### DIFF
--- a/oss-licenses-plugin/README.md
+++ b/oss-licenses-plugin/README.md
@@ -22,6 +22,29 @@ play-services-oss-licenses library.
 
 ### Add the Gradle plugin
 
+#### Plugins DSL
+
+Add the following to your project's settings.gradle:
+
+```groovy
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+    }
+}
+```
+
+Apply the plugin in your app's build.gradle:
+
+```groovy
+plugins {
+    id 'com.google.gms.oss-licenses-plugin' version '0.10.5'
+}
+```
+
+#### Legacy way
+
 In your root-level `build.gradle` make sure you are using the
 [Google Maven repository](https://developer.android.com/studio/build/dependencies#google-maven)
 and add the oss-licenses plugin to your dependencies:

--- a/oss-licenses-plugin/build.gradle
+++ b/oss-licenses-plugin/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'groovy'
 apply plugin: 'java'
+apply plugin: 'java-gradle-plugin'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -19,35 +20,20 @@ dependencies {
 
 group = 'com.google.android.gms'
 version = '0.10.5'
-
-apply plugin: 'maven'
+project.ext.archivesBaseName = 'oss-licenses-plugin'
 
 repositories {
     google()
     mavenCentral()
 }
 
-// upload and build in local
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            repository(url: uri('../repo'))
-            pom.project {
-                licenses {
-                    license {
-                        name 'The Apache Software License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                        distribution 'repo'
-                    }
-                }
-
-            }
+gradlePlugin {
+    plugins {
+        ossLicensesPlugin {
+            id = 'com.google.android.gms.oss-licenses-plugin'
+            implementationClass = 'com.google.android.gms.oss.licenses.plugin.OssLicensesPlugin'
         }
     }
 }
 
-// generate zip file for android maven release tool
-task packageFiles(type: Zip, dependsOn: 'uploadArchives') {
-    def groupDir = rootProject.group.replaceAll('\\.', '/')
-    from("../repo/$groupDir/$rootProject.name/$rootProject.version/")
-}
+apply from: 'publish.gradle'

--- a/oss-licenses-plugin/publish.gradle
+++ b/oss-licenses-plugin/publish.gradle
@@ -1,0 +1,33 @@
+apply plugin: 'maven-publish'
+
+jar {
+    from 'LICENSE'
+}
+
+task sourcesJar(type: Jar, dependsOn:classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+publishing {
+    publications {
+        pluginMaven(MavenPublication) {
+            artifactId project.ext.archivesBaseName
+
+            artifact sourcesJar
+
+            pom {
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+            }
+        }
+    }
+}
+
+publishing.repositories.maven {
+    url "$buildDir/repo"
+}


### PR DESCRIPTION
See #50 

This PR bases most of the changes from #51 which added the plugin marker for google-services-plugin, and also adds a separate `publish.gradle` file which previously did not exist.