### PR TITLE
Fix google services compatibility with crashlytics

### DIFF
--- a/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesTask.java
+++ b/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesTask.java
@@ -34,6 +34,7 @@ import org.gradle.api.resources.TextResource;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
@@ -74,6 +75,12 @@ public abstract class GoogleServicesTask extends DefaultTask {
 
   @OutputDirectory
   public abstract DirectoryProperty getOutputDirectory();
+
+  /** Reintroduced for binary compatiblity with the crashlytics plugin */
+  @Internal
+  public File getIntermediateDir() {
+    return getOutputDirectory().getAsFile().get();
+  }
 
   @Input
   public String getBuildType() {


### PR DESCRIPTION
Add back getIntermediateDir() method for binary compatibility as it
appears the crashlytics plugin depends on that getter.

Bug: https://issuetracker.google.com/237071883