### PR TITLE
Add google-services.json as a task input, to fix up-to-date checks

### DIFF
--- a/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesPlugin.groovy
+++ b/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesPlugin.groovy
@@ -20,10 +20,6 @@ import com.google.android.gms.dependencies.DependencyAnalyzer
 import com.google.android.gms.dependencies.DependencyInspector
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.model.ObjectFactory
-
-import java.util.regex.Matcher
-import java.util.regex.Pattern
 
 class GoogleServicesPlugin implements Plugin<Project> {
   public final static String MODULE_GROUP = "com.google.android.gms"
@@ -121,15 +117,20 @@ class GoogleServicesPlugin implements Plugin<Project> {
     File outputDir =
         project.file("$project.buildDir/generated/res/google-services/$variant.dirName")
 
+    def googleServicesFiles =
+            GoogleServicesTask.getJsonLocations(
+                    variant.buildType.name,
+                    variant.productFlavors.collect { it.name })
+
     def processTask = project
           .tasks
           .register(
             "process${variant.name.capitalize()}GoogleServices",
-             GoogleServicesTask) { task ->
-              task.outputDirectory.set(outputDir)
-              task.applicationId.set(variant.applicationId)
-              task.setBuildType(variant.buildType.name)
-              task.setProductFlavors(variant.productFlavors.collect { it.name })
+             GoogleServicesTask) {
+              outputDirectory.set(outputDir)
+              applicationId.set(variant.applicationId)
+              // from maintains the ordering of the sorted file collection.
+              googleServicesJsonFiles.from(googleServicesFiles)
             }
     if (variant.respondsTo("registerGeneratedResFolders")) {
       variant.registerGeneratedResFolders(

--- a/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesTask.java
+++ b/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesTask.java
@@ -27,13 +27,12 @@ import com.google.gson.JsonPrimitive;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileSystemLocation;
 
 import org.gradle.api.provider.Property;
-import org.gradle.api.resources.TextResource;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFile;
-import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
@@ -43,13 +42,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 
@@ -64,13 +58,8 @@ public abstract class GoogleServicesTask extends DefaultTask {
 
   private static final String OAUTH_CLIENT_TYPE_WEB = "3";
 
-  private String buildType;
-  private List<String> productFlavors;
-  private ObjectFactory objectFactory;
-
   @Inject
-  public GoogleServicesTask(ObjectFactory objectFactory) {
-    this.objectFactory = objectFactory;
+  public GoogleServicesTask() {
   }
 
   @OutputDirectory
@@ -82,23 +71,10 @@ public abstract class GoogleServicesTask extends DefaultTask {
     return getOutputDirectory().getAsFile().get();
   }
 
-  @Input
-  public String getBuildType() {
-    return buildType;
-  }
+  @InputFiles
+  final FileCollection googleServicesJsonFiles = getProject().getObjects().fileCollection();
 
-  @Input
-  public List<String> getProductFlavors() {
-    return productFlavors;
-  }
-
-  public void setBuildType(String buildType) {
-    this.buildType = buildType;
-  }
-
-  public void setProductFlavors(List<String> productFlavors) {
-    this.productFlavors = productFlavors;
-  }
+  public FileCollection getGoogleServicesJsonFiles() { return googleServicesJsonFiles; }
 
   @Input
   public abstract Property<String> getApplicationId();
@@ -106,9 +82,9 @@ public abstract class GoogleServicesTask extends DefaultTask {
   @TaskAction
   public void action() throws IOException {
     File quickstartFile = null;
-    List<String> fileLocations = getJsonLocations(buildType, productFlavors);
     String searchedLocation = System.lineSeparator();
-    for (File jsonFile : objectFactory.fileCollection().from(fileLocations)) {
+    for (FileSystemLocation jsonFileLoc : googleServicesJsonFiles.getElements().get()) {
+      File jsonFile = jsonFileLoc.getAsFile();
       searchedLocation = searchedLocation + jsonFile.getPath() + System.lineSeparator();
       if (jsonFile.isFile()) {
         quickstartFile = jsonFile;


### PR DESCRIPTION
`google-services.json` was not previously treated as a task input, so changes to that file would not cause the task's UP-TO-DATE check to return `false`. As a result, the generated `values.xml` file is never updated unless `clean` is run after editing the json file, which seems buggy and has customer problems.

See [this issue](https://github.com/firebase/firebase-android-sdk/issues/2191) in the firebase-android-sdk repo, as an example.