### PR TITLE
Add call to notCompatibleWithConfigurationCache to LicensesTask

### DIFF
--- a/oss-licenses-plugin/build.gradle
+++ b/oss-licenses-plugin/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 }
 
 group = 'com.google.android.gms'
-version = '0.10.5'
+version = '0.10.6'
 
 apply plugin: 'maven'
 


### PR DESCRIPTION
Calling [notCompatibleWithConfigurationCache](https://docs.gradle.org/current/javadoc/org/gradle/api/Task.html#notCompatibleWithConfigurationCache-java.lang.String-) on the `LicensesTask` will prevent the build failure and instead only warn of the issue the first time it is encountered. We do a `respondsTo` method check before calling it. The method was added as incubating in Gradle 7.4 and may be removed in a future version.

We use the Project object during `LicensesTask` execution to query the location of POM files and any Play Services SDKs to extract license information. We don't know which artifact IDs to use in those queries until the AGP task that produces the information has run. It's a bit of a circular problem, but we can at least prevent the build halting error.

Running repeated builds still results in <= 1 second build time for a test project.

fix #206