### PR TITLE
Replaced capitalize() method to mitigate issue with camelCase flavors

### DIFF
--- a/google-services-plugin/build.gradle
+++ b/google-services-plugin/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'com.google.android.gms:strict-version-matcher-plugin:1.2.4'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.google.guava:guava:27.0.1-jre'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.google.truth:truth:0.42'
 }

--- a/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesPlugin.groovy
+++ b/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesPlugin.groovy
@@ -164,7 +164,8 @@ class GoogleServicesPlugin implements Plugin<Project> {
       "com.android.model.application"
     ]),
     MODEL_LIBRARY(["com.android.model.library"])
-    public PluginType(Collection plugins) {
+    
+    PluginType(Collection plugins) {
       this.plugins = plugins
     }
     private final Collection plugins

--- a/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesTask.java
+++ b/google-services-plugin/src/main/groovy/com/google/gms/googleservices/GoogleServicesTask.java
@@ -24,6 +24,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
+import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.DirectoryProperty;
@@ -458,20 +459,20 @@ public abstract class GoogleServicesTask extends DefaultTask {
 
   static List<String> getJsonLocations(String buildType, List<String> flavorNames) {
     List<String> fileLocations = new ArrayList<>();
-    String flavorName = flavorNames.stream().reduce("", (a,b) -> a + (a.length() == 0 ? b : capitalize(b)));
+    String flavorName = flavorNames.stream().reduce("", (a, b) -> a + (a.length() == 0 ? b : StringUtils.capitalize(b)));
     fileLocations.add("");
     fileLocations.add("src/" + flavorName + "/" + buildType);
     fileLocations.add("src/" + buildType + "/" + flavorName);
     fileLocations.add("src/" + flavorName);
     fileLocations.add("src/" + buildType);
-    fileLocations.add("src/" + flavorName + capitalize(buildType));
+    fileLocations.add("src/" + flavorName + StringUtils.capitalize(buildType));
     fileLocations.add("src/" + buildType);
     String fileLocation = "src";
     for(String flavor : flavorNames) {
       fileLocation += "/" + flavor;
       fileLocations.add(fileLocation);
       fileLocations.add(fileLocation + "/" + buildType);
-      fileLocations.add(fileLocation + capitalize(buildType));
+      fileLocations.add(fileLocation + StringUtils.capitalize(buildType));
     }
     fileLocations = fileLocations
         .stream()
@@ -480,10 +481,5 @@ public abstract class GoogleServicesTask extends DefaultTask {
         .map(location -> location.isEmpty() ? location + JSON_FILE_NAME : location + '/' + JSON_FILE_NAME)
         .collect(toList());
     return fileLocations;
-  }
-
-  public static String capitalize(String s) {
-      if (s.length() == 0) return s;
-      return s.substring(0, 1).toUpperCase() + s.substring(1).toLowerCase();
   }
 }

--- a/google-services-plugin/src/test/java/com/google/gms/googleservices/GoogleServicesPluginTest.java
+++ b/google-services-plugin/src/test/java/com/google/gms/googleservices/GoogleServicesPluginTest.java
@@ -65,6 +65,25 @@ public class GoogleServicesPluginTest {
             "src/flavor/testRelease/google-services.json");
   }
 
+  @Test
+  public void testMultipleFlavorsWithCamelCase() {
+    List<String> output =
+        toStringList(GoogleServicesTask.getJsonLocations("release", Arrays.asList("flavor", "testTest")));
+    assertThat(output)
+        .containsAllOf(
+            "google-services.json",
+            "src/release/google-services.json",
+            "src/flavorRelease/google-services.json",
+            "src/flavor/google-services.json",
+            "src/flavor/release/google-services.json",
+            "src/release/flavorTestTest/google-services.json",
+            "src/flavorTestTest/google-services.json",
+            "src/flavorTestTestRelease/google-services.json",
+            "src/flavor/testTest/release/google-services.json",
+            "src/flavor/testTestRelease/google-services.json");
+  }
+
+
   // This is necessary because some of the strings are actually groovy string implementations
   // which fail equality tests with java strings during testing
   private static List<String> toStringList(List<String> input) {


### PR DESCRIPTION
I used [Apache Commons](https://commons.apache.org/proper/commons-lang/) for the capitalization, which may be unreasonable. So if it's not okay to use Commons, it's possible to rewrite the existing method to not interfere with the camelCase names of the flavors.

I've added a test case for the issue, so you can see that it will fail without the fix.

Also, compilation failed for me because of the `public` modifier in the enum, so I changed that as well.

Closes #183 