### PR TITLE
oss-license-plugin: sort ArtifactInfo into list

### DIFF
--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/DependencyTask.groovy
@@ -76,7 +76,7 @@ abstract class DependencyTask extends DefaultTask {
         } as AppDependencies
     }
 
-    private static Set<ArtifactInfo> convertDependenciesToArtifactInfo(
+    private static List<ArtifactInfo> convertDependenciesToArtifactInfo(
             AppDependencies appDependencies
     ) {
         return appDependencies.libraryList.stream()
@@ -88,7 +88,8 @@ abstract class DependencyTask extends DefaultTask {
                             library.mavenLibrary.version
                     )
                 }
-                .collect(Collectors.toUnmodifiableSet())
+                .sorted(Comparator.comparing { it.toString() })
+                .collect(Collectors.toUnmodifiableList())
     }
 
     private static void initOutput(File outputDir) {

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.slf4j.LoggerFactory
 
+import java.util.stream.Collectors
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 
@@ -114,7 +115,9 @@ abstract class LicensesTask extends DefaultTask {
             ArtifactInfo artifactInfo = artifactInfoFromEntry(entry)
             artifactInfoSet.add(artifactInfo)
         }
-        artifactInfoSet.toList().asImmutable()
+        artifactInfoSet.stream()
+                .sorted(Comparator.comparing { it.toString() })
+                .collect(Collectors.toUnmodifiableList())
     }
 
     private void addDebugLicense() {

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
@@ -107,14 +107,14 @@ abstract class LicensesTask extends DefaultTask {
         writeMetadata()
     }
 
-    private static Set<ArtifactInfo> loadDependenciesJson(File jsonFile) {
+    private static List<ArtifactInfo> loadDependenciesJson(File jsonFile) {
         def allDependencies = new JsonSlurper().parse(jsonFile)
         def artifactInfoSet = new HashSet<ArtifactInfo>()
         for (entry in allDependencies) {
             ArtifactInfo artifactInfo = artifactInfoFromEntry(entry)
             artifactInfoSet.add(artifactInfo)
         }
-        artifactInfoSet.asImmutable()
+        artifactInfoSet.toList().asImmutable()
     }
 
     private void addDebugLicense() {


### PR DESCRIPTION
This should ensure that the output of third_party_licenses and third_party_licenses_metadata is sorted. Sorting the output will make it reproducible regardless of the input ordering.

This is necessary to have reproducible build when using the plugin.