### PR TITLE
Fix dependency in `gradle-api`

### DIFF
--- a/google-services-plugin/build.gradle.kts
+++ b/google-services-plugin/build.gradle.kts
@@ -23,8 +23,7 @@ group = "com.google.gms"
 version = "4.4.0"
 
 dependencies {
-    compileOnly(gradleApi())
-    implementation("com.android.tools.build:gradle-api:7.3.0")
+    compileOnly("com.android.tools.build:gradle-api:7.3.0")
     implementation("com.google.android.gms:strict-version-matcher-plugin:1.2.4")
     implementation("com.google.code.gson:gson:2.8.5")
     implementation("com.google.guava:guava:27.0.1-jre")


### PR DESCRIPTION
re: b/313211009

It should be `compileOnly` instead of `implementation`. This prevents the protobuf dependency in `gradle-api` from leaking to the plugin and causing inexpected issues.