### PR TITLE
Make gmpAppId variant aware

### DIFF
--- a/google-services-plugin/src/main/kotlin/com/google/gms/googleservices/GoogleServicesPlugin.kt
+++ b/google-services-plugin/src/main/kotlin/com/google/gms/googleservices/GoogleServicesPlugin.kt
@@ -92,7 +92,7 @@ class GoogleServicesPlugin : Plugin<Project> {
                       variant.productFlavors.map { it.second },
                       project.projectDir))
               it.applicationId.set(variant.applicationId)
-              it.gmpAppId.set(project.buildDir.resolve("gmpAppId.txt"))
+              it.gmpAppId.set(project.buildDir.resolve("crashlytics/${variant.name}/gmpAppId.txt"))
             }
 
     // TODO: add an AGP version check to this block

--- a/google-services-plugin/src/main/kotlin/com/google/gms/googleservices/GoogleServicesPlugin.kt
+++ b/google-services-plugin/src/main/kotlin/com/google/gms/googleservices/GoogleServicesPlugin.kt
@@ -92,7 +92,7 @@ class GoogleServicesPlugin : Plugin<Project> {
                       variant.productFlavors.map { it.second },
                       project.projectDir))
               it.applicationId.set(variant.applicationId)
-              it.gmpAppId.set(project.buildDir.resolve("crashlytics/${variant.name}/gmpAppId.txt"))
+              it.gmpAppId.set(project.buildDir.resolve("gmpAppId/${variant.name}.txt"))
             }
 
     // TODO: add an AGP version check to this block


### PR DESCRIPTION
Make the `gmpAppId.txt` output file variant aware. This is to support parallel builds in the latest Crashlytics Gradle plugin, which consumes this output, see https://github.com/firebase/firebase-android-sdk/issues/5962.