### PR TITLE
Remove usage of deprecated org.gradle.configurationcache.extensions.capitalized

### DIFF
--- a/google-services-plugin/src/main/kotlin/com/google/gms/googleservices/GoogleServicesPlugin.kt
+++ b/google-services-plugin/src/main/kotlin/com/google/gms/googleservices/GoogleServicesPlugin.kt
@@ -25,7 +25,6 @@ import java.io.File
 import java.util.*
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.configurationcache.extensions.capitalized
 
 class GoogleServicesPlugin : Plugin<Project> {
 


### PR DESCRIPTION
This method is deprecated in Gradle. I tried to removed this extension for Gradle 9 (see https://github.com/gradle/gradle/pull/33476), but that breaks your plugin