### PR TITLE
[GithubAction] Bump Github actions to valid versions

### DIFF
--- a/.github/workflows/generate_release_rcs.yml
+++ b/.github/workflows/generate_release_rcs.yml
@@ -29,12 +29,12 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       # Runs a build which includes `check` and `test` tasks
       - run: ./gradlew build
         working-directory: ./${{ matrix.project-dir }}
       - name: Upload generated artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: ${{ matrix.project-dir }}
           path: ./${{ matrix.project-dir }}/build/libs
@@ -44,11 +44,11 @@ jobs:
   build-google-services:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Perform a Gradle build
         run: cd google-services-plugin && ./gradlew publish
       - name: Upload generated artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: google-services-plugin
           path: google-services-plugin/build/repo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       # Runs a build which includes `check` and `test` tasks
       - name: Perform a Gradle build
         run: ./gradlew build


### PR DESCRIPTION
Our workflows were using not only outdated, but no longer supported versions of the checkout and upload-artifact actions.