### PR TITLE
Update google-services-plugin version

### DIFF
--- a/google-services-plugin/build.gradle.kts
+++ b/google-services-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 }
 
 group = "com.google.gms"
-version = "4.4.1"
+version = "4.4.3"
 
 dependencies {
     compileOnly("com.android.tools.build:gradle-api:7.3.0")


### PR DESCRIPTION
Bump version to the next unreleased patch version.

Version 4.4.2 is already released, see https://maven.google.com/web/index.html?q=google-#com.google.gms.google-services:com.google.gms.google-services.gradle.plugin:4.4.2