### PR TITLE
Enable publishing plugin marker

### DIFF
--- a/oss-licenses-plugin/README.md
+++ b/oss-licenses-plugin/README.md
@@ -22,33 +22,29 @@ play-services-oss-licenses library.
 
 ### Add the Gradle plugin
 
-In your root-level `build.gradle` make sure you are using the
-[Google Maven repository](https://developer.android.com/studio/build/dependencies#google-maven)
-and add the oss-licenses plugin to your dependencies:
+In your root-level `settings.gradle.kts` make sure you are using the
+[Google Maven repository](https://developer.android.com/studio/build/dependencies#google-maven):
 
-    buildscript {
+    pluginManagement {
       repositories {
-        // ...
-        google()  // or maven { url "https://maven.google.com" } for Gradle <= 3
+        google()
       }
-      dependencies {
-        // ...
-        // Add this line:
-        classpath 'com.google.android.gms:oss-licenses-plugin:0.10.6'
-      }
+    }
 
-In your app-level `build.gradle`, apply the plugin by adding the following line
-under the existing `apply plugin: 'com.android.application'` at the top of the
+In your app-level `build.gradle.kts`, apply the plugin by adding the following line
+under the existing `id("com.android.application")` at the top of the
 file:
 
-    apply plugin: 'com.google.android.gms.oss-licenses-plugin'
+    apply {
+      id("com.google.android.gms.oss-licenses-plugin") version("0.10.7")
+    }
 
 ### Add the library to your app
 
-In the `dependencies` section of your app-level `build.gradle`, add a dependency
+In the `dependencies` section of your app-level `build.gradle.kts`, add a dependency
 on the `oss-licenses` library:
 
-    implementation 'com.google.android.gms:play-services-oss-licenses:17.0.0'
+    implementation("com.google.android.gms:play-services-oss-licenses:17.0.0")
 
 ### Displaying license information
 

--- a/oss-licenses-plugin/build.gradle.kts
+++ b/oss-licenses-plugin/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("groovy")
+    id("groovy")
     id("java-gradle-plugin")
     id("org.jetbrains.kotlin.jvm") version "2.2.0"
     id("com.gradle.plugin-publish") version "1.1.0"
@@ -57,14 +57,12 @@ publishing {
             artifactId = "oss-licenses-plugin"
         }
     }
-    afterEvaluate {
-        publications.withType(MavenPublication::class.java) {
-            pom {
-                licenses {
-                    license {
-                        name.set("The Apache License, Version 2.0")
-                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                    }
+    publications.withType<MavenPublication>().configureEach {
+        pom {
+            licenses {
+                license {
+                    name.set("The Apache License, Version 2.0")
+                    url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
                 }
             }
         }


### PR DESCRIPTION
This will allow an easier way for users to apply this Gradle plugin using Gradle best pratices https://docs.gradle.org/current/userguide/best_practices_general.html#use_the_plugins_block

Fixes https://github.com/google/play-services-plugins/issues/50