### PR TITLE
Simplify LicensesCleanUpTask

### DIFF
--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesCleanUpTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesCleanUpTask.groovy
@@ -17,44 +17,26 @@
 package com.google.android.gms.oss.licenses.plugin
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 /**
- * Task to clean up the generated dependency.json, third_party_licenses and
- * third_party_license_metadata files.
+ * Task to clean up the generated files.
  */
-class LicensesCleanUpTask extends DefaultTask {
-
-    protected File dependenciesJson
-
-    protected File dependencyDir
-
-    protected File licensesFile
-
-    protected File metadataFile
-
-    protected File licensesDir
+@DisableCachingByDefault(because = "Local deletion operation")
+abstract class LicensesCleanUpTask extends DefaultTask {
+    @Optional
+    @InputDirectory
+    abstract DirectoryProperty getGeneratedDirectory()
 
     @TaskAction
     void action() {
-        if (dependenciesJson.exists()) {
-            dependenciesJson.delete()
-        }
-
-        if (dependencyDir.isDirectory() && dependencyDir.list().length == 0) {
-            dependencyDir.delete()
-        }
-
-        if (licensesFile.exists()) {
-            licensesFile.delete()
-        }
-
-        if (metadataFile.exists()) {
-            metadataFile.delete()
-        }
-
-        if (licensesDir.isDirectory() && licensesDir.list().length == 0) {
-            licensesDir.delete()
+        File directoryToDelete = getGeneratedDirectory().get().asFile
+        if (directoryToDelete.exists()) {
+            directoryToDelete.deleteDir()
         }
     }
 }

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
@@ -32,7 +32,7 @@ class OssLicensesPlugin implements Plugin<Project> {
         def variantTolicenseTaskMap = new HashMap<String, LicensesTask>()
         project.androidComponents {
             onVariants(selector().all(), { variant ->
-                def baseDir = new File(project.buildDir,
+                File baseDir = new File(project.buildDir,
                         "generated/third_party_licenses/${variant.name}")
                 def dependenciesJson = new File(baseDir, "dependencies.json")
 
@@ -68,11 +68,7 @@ class OssLicensesPlugin implements Plugin<Project> {
                 TaskProvider<LicensesCleanUpTask> cleanupTask = project.tasks.register(
                         cleanupTaskName,
                         LicensesCleanUpTask.class) {
-                    it.dependenciesJson = dependenciesJson
-                    it.dependencyDir = baseDir
-                    it.licensesFile = licensesFile
-                    it.metadataFile = licensesMetadataFile
-                    it.licensesDir = rawResourceDir
+                    it.generatedDirectory.set(baseDir)
                 }
                 logger.debug("Registered task $cleanupTaskName")
 

--- a/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/LicensesCleanUpTaskTest.java
+++ b/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/LicensesCleanUpTaskTest.java
@@ -15,6 +15,7 @@
 package com.google.android.gms.oss.licenses.plugin;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,31 +38,28 @@ public class LicensesCleanUpTaskTest {
   public void testAction() throws IOException {
     File testDir = temporaryFolder.newFolder();
 
-    File dependencyDir = new File(testDir, "dependency");
-    dependencyDir.mkdir();
-
+    // Set up a generated directory with normal expected contents
+    File generatedDir = new File(testDir, "generated");
+    File dependencyDir = new File(generatedDir, "dependency");
+    assertTrue(dependencyDir.mkdirs());
     File dependencyFile = new File(dependencyDir, "dependency.json");
+    assertTrue(dependencyFile.createNewFile());
 
-    File licensesDir = new File(testDir, "raw");
-    licensesDir.mkdir();
+    File licensesDir = new File(generatedDir, "res/raw");
+    assertTrue(licensesDir.mkdirs());
+    assertTrue(new File(licensesDir, "third_party_licenses").createNewFile());
+    assertTrue(new File(licensesDir, "third_party_license_metadata").createNewFile());
 
-    File licensesFile = new File(licensesDir, "third_party_licenses");
-    File metadataFile = new File(licensesDir, "third_party_license_metadata");
-
+    // Create a licenses clean up task
     Project project = ProjectBuilder.builder().withProjectDir(testDir).build();
     LicensesCleanUpTask task =
         project.getTasks().create("licensesCleanUp", LicensesCleanUpTask.class);
-    task.dependencyDir = dependencyDir;
-    task.dependenciesJson = dependencyFile;
-    task.licensesDir = licensesDir;
-    task.licensesFile = licensesFile;
-    task.metadataFile = metadataFile;
+    task.getGeneratedDirectory().set(generatedDir);
 
+    // Run the task action
     task.action();
-    assertFalse(task.dependenciesJson.exists());
-    assertFalse(task.dependencyDir.exists());
-    assertFalse(task.licensesFile.exists());
-    assertFalse(task.metadataFile.exists());
-    assertFalse(task.licensesDir.exists());
+
+    // Ensure the directory is deleted
+    assertFalse(generatedDir.exists());
   }
 }


### PR DESCRIPTION
Delete the entire directory instead of individual files. This is in prepration to moving LicensesTask to a single output directory to make it compatible with the new AGP variants API.