### PR TITLE
Fix LicensesTaskTest from leaving stray files in source tree

### DIFF
--- a/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/LicensesTaskTest.java
+++ b/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/LicensesTaskTest.java
@@ -62,11 +62,12 @@ public class LicensesTaskTest {
 
   @Before
   public void setUp() throws IOException {
+    File projectDir = temporaryFolder.newFolder();
     File outputDir = temporaryFolder.newFolder();
     File outputLicenses = new File(outputDir, "testLicenses");
     File outputMetadata = new File(outputDir, "testMetadata");
 
-    project = ProjectBuilder.builder().withProjectDir(new File(BASE_DIR)).build();
+    project = ProjectBuilder.builder().withProjectDir(projectDir).build();
     licensesTask = project.getTasks().create("generateLicenses", LicensesTask.class);
 
     licensesTask.setRawResourceDir(outputDir);


### PR DESCRIPTION
Before this change LicensesTaskTest was using src/test/resources as Gradle project directory. This means it was leaving stray src/test/resources/userHome/ directory around every time this test was run. Instead, move to a new temporary directory.

Test: ./gradlew test