### PR TITLE
Disable adding stdlib to POM

### DIFF
--- a/oss-licenses-plugin/gradle.properties
+++ b/oss-licenses-plugin/gradle.properties
@@ -1,0 +1,2 @@
+# This project does not use Kotlin in production yet, so prevent adding the Kotlin dependencies.
+kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
The dependency was accidentally added in #314, but only used in tests.

This PR fixes #324