### PR TITLE
Remove usage of deprecated org.gradle.configurationcache.extensions.capitalized

### DIFF
--- a/google-services-plugin/src/main/kotlin/com/google/gms/googleservices/GoogleServicesPlugin.kt
+++ b/google-services-plugin/src/main/kotlin/com/google/gms/googleservices/GoogleServicesPlugin.kt
@@ -25,7 +25,6 @@ import java.io.File
 import java.util.*
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.configurationcache.extensions.capitalized
 
 class GoogleServicesPlugin : Plugin<Project> {
 
@@ -171,3 +170,6 @@ class GoogleServicesPlugin : Plugin<Project> {
     var missingGoogleServicesStrategy = MissingGoogleServicesStrategy.ERROR
   }
 }
+
+private fun CharSequence.capitalized(): String =
+    toString().replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }


### PR DESCRIPTION
This method is deprecated and slated to be deleted https://github.com/gradle/gradle/blob/master/platforms/core-configuration/stdlib-kotlin-extensions/src/main/kotlin/org/gradle/configurationcache/extensions/CharSequenceExtensions.kt#L25

Test: ./gradlew test