### PR TITLE
Upgrade KGP from 1.7.22 to 2.1.0

### DIFF
--- a/google-services-plugin/build.gradle.kts
+++ b/google-services-plugin/build.gradle.kts
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
 plugins {
     id("java-gradle-plugin")
-    id("org.jetbrains.kotlin.jvm") version "1.7.22"
+    id("org.jetbrains.kotlin.jvm") version "2.1.0"
     id("com.gradle.plugin-publish") version "1.1.0"
 }
 
@@ -56,6 +59,10 @@ java {
 
 kotlin {
     jvmToolchain(11)
+    coreLibrariesVersion = "1.7.10"
+    compilerOptions {
+        languageVersion.set(KotlinVersion.KOTLIN_1_7)
+    }
 }
 
 tasks.withType<Test>().configureEach {

--- a/google-services-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/google-services-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
We keep compatibility with Kotlin language 1.7 and use stdlib 1.7.10 making sure there is no effect on end users.

Test: ./gradlew test