### PR TITLE
Bumpd oss licenses plugin version to 0.10.9.

### DIFF
--- a/oss-licenses-plugin/build.gradle.kts
+++ b/oss-licenses-plugin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.google.android.gms"
-version = "0.10.8"
+version = "0.10.9"
 
 repositories {
     google()


### PR DESCRIPTION
Bump the oss licenses plugin version for new release.