### PR TITLE
Wire `LicensesTask` to Android resources source set

### DIFF
--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/OssLicensesPlugin.groovy
@@ -57,7 +57,7 @@ class OssLicensesPlugin implements Plugin<Project> {
             it.dependenciesJson.set(dependencyTask.flatMap { it.dependenciesJson })
         }
         project.logger.debug("Registered task ${licenseTask.name}")
-        variant.sources.resources.addGeneratedSourceDirectory(licenseTask, LicensesTask::getGeneratedDirectory)
+        variant.sources.res.addGeneratedSourceDirectory(licenseTask, LicensesTask::getGeneratedDirectory)
 
         TaskProvider<LicensesCleanUpTask> cleanupTask = project.tasks.register(
                 "${variant.name}OssLicensesCleanUp",

--- a/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/EndToEndTest.kt
+++ b/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/EndToEndTest.kt
@@ -89,7 +89,7 @@ class EndToEndTest(private val agpVersion: String, private val gradleVersion: St
         Assert.assertEquals(expectedDependenciesJson(isBuiltInKotlinEnabled()), dependenciesJson.readText())
 
         val metadata =
-            File(projectDir, "build/generated/resources/releaseOssLicensesTask/raw/third_party_license_metadata")
+            File(projectDir, "build/generated/res/releaseOssLicensesTask/raw/third_party_license_metadata")
         Assert.assertEquals(expectedContents(isBuiltInKotlinEnabled()), metadata.readText())
 
         val cleanResult = GradleRunner.create()


### PR DESCRIPTION
Use `Sources#res` instead of `Sources#resources` when wiring `LicensesTask`.

Fixes #346