### PR TITLE
Fix #358

### DIFF
--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
@@ -126,7 +126,7 @@ abstract class LicensesTask extends DefaultTask {
     }
 
     protected void initOutputDir() {
-        File resourceBaseDir = new File(getGeneratedDirectory().get().asFile, "/res")
+        File resourceBaseDir = new File(getGeneratedDirectory().get().asFile, "res")
         File rawResourceDir = new File(resourceBaseDir, "raw")
         if (!rawResourceDir.exists()) {
             rawResourceDir.mkdirs()


### PR DESCRIPTION
The path where the "third_party_license_metadata" and "third_party_licenses" files are stored has been changed from "raw" to "res/raw" to make it accessible from the application, fixing bug #358