### PR TITLE
build(oss-licenses): upgrade to Gradle 9.4.1 and AGP 9.1.0

### DIFF
--- a/oss-licenses-plugin/build.gradle.kts
+++ b/oss-licenses-plugin/build.gradle.kts
@@ -49,8 +49,8 @@ gradlePlugin {
 }
 
 dependencies {
-    compileOnly("com.android.tools.build:gradle:9.0.1")
-    compileOnly("com.android.tools.build:gradle-api:9.0.1")
+    compileOnly("com.android.tools.build:gradle:9.1.0")
+    compileOnly("com.android.tools.build:gradle-api:9.1.0")
     implementation(gradleApi())
     implementation(localGroovy())
     implementation("com.google.protobuf:protobuf-java:4.34.0")
@@ -60,7 +60,7 @@ dependencies {
     testImplementation("com.google.guava:guava:33.4.0-jre")
     testImplementation("com.google.truth:truth:1.4.4")
     testImplementation("com.google.code.gson:gson:2.12.1")
-    testImplementation("com.android.tools.build:gradle:9.0.1") {
+    testImplementation("com.android.tools.build:gradle:9.1.0") {
         because("Needed for DependencyTaskTest.")
     }
 }

--- a/oss-licenses-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/oss-licenses-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/oss-licenses-plugin/testapp/gradle/libs.versions.toml
+++ b/oss-licenses-plugin/testapp/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.0.1"
+agp = "9.1.0"
 androidx-activity = "1.13.0"
 androidx-appcompat = "1.7.1"
 androidx-compose-bom = "2026.03.00"

--- a/oss-licenses-plugin/testapp/gradle/wrapper/gradle-wrapper.properties
+++ b/oss-licenses-plugin/testapp/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Updates Gradle to 9.4.1 and AGP to 9.1.0 for the oss-licenses-plugin and its testapp.