### PR TITLE
feat(testapp): Update test app and add library version display

### DIFF
--- a/oss-licenses-plugin/testapp/app/build.gradle.kts
+++ b/oss-licenses-plugin/testapp/app/build.gradle.kts
@@ -78,6 +78,18 @@ androidComponents {
         // We explicitly enable them for all variants to ensure both Debug and Release coverage.
         variantBuilder.hostTests[HostTestBuilder.UNIT_TEST_TYPE]?.enable = true
     }
+
+    onVariants { variant ->
+        val generateTask = tasks.register<GenerateVersionTask>("generateVersionResource_${variant.name}") {
+            libraryDependenciesReport.set(variant.artifacts.get(com.android.build.api.artifact.SingleArtifact.METADATA_LIBRARY_DEPENDENCIES_REPORT))
+            outputDir.set(layout.buildDirectory.dir("generated/oss_res/${variant.name}"))
+        }
+
+        variant.sources.res?.addGeneratedSourceDirectory(
+            generateTask,
+            GenerateVersionTask::outputDir
+        )
+    }
 }
 
 kotlin {
@@ -105,4 +117,34 @@ dependencies {
     testImplementation(platform(libs.androidx.compose.bom))
     testImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
+}
+
+abstract class GenerateVersionTask : DefaultTask() {
+    @get:org.gradle.api.tasks.InputFile
+    @get:org.gradle.api.tasks.Optional
+    abstract val libraryDependenciesReport: org.gradle.api.file.RegularFileProperty
+
+    @get:org.gradle.api.tasks.OutputDirectory
+    abstract val outputDir: org.gradle.api.file.DirectoryProperty
+
+    @org.gradle.api.tasks.TaskAction
+    fun doAction() {
+        val versionFile = outputDir.get().file("raw/version.txt").asFile
+        versionFile.parentFile.mkdirs()
+
+        val reportFile = libraryDependenciesReport.get().asFile
+        val appDependencies = reportFile.inputStream().use {
+             com.android.tools.build.libraries.metadata.AppDependencies.parseFrom(it)
+        }
+
+        val ossLicensesLibrary = appDependencies.libraryList.find {
+            it.libraryOneofCase.name == "MAVEN_LIBRARY" &&
+            it.mavenLibrary.groupId == "com.google.android.gms" &&
+            it.mavenLibrary.artifactId == "play-services-oss-licenses"
+        }
+
+        val version = ossLicensesLibrary?.mavenLibrary?.version ?: "UNKNOWN"
+        versionFile.writeText(version)
+        println("Generated version.txt with version: $version")
+    }
 }

--- a/oss-licenses-plugin/testapp/app/build.gradle.kts
+++ b/oss-licenses-plugin/testapp/app/build.gradle.kts
@@ -132,6 +132,11 @@ abstract class GenerateVersionTask : DefaultTask() {
         val versionFile = outputDir.get().file("raw/version.txt").asFile
         versionFile.parentFile.mkdirs()
 
+        if (!libraryDependenciesReport.isPresent) {
+            versionFile.writeText("UNKNOWN")
+            return
+        }
+
         val reportFile = libraryDependenciesReport.get().asFile
         val appDependencies = reportFile.inputStream().use {
              com.android.tools.build.libraries.metadata.AppDependencies.parseFrom(it)

--- a/oss-licenses-plugin/testapp/app/src/main/AndroidManifest.xml
+++ b/oss-licenses-plugin/testapp/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools">
     <application
         android:allowBackup="true"
         android:label="OSS Licenses Test App"
@@ -13,5 +14,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name="com.google.android.gms.oss.licenses.v2.OssLicensesMenuActivity"
+            android:exported="true" />
+        <activity
+            android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
+            android:theme="@style/Theme.CustomOssTheme"
+            tools:replace="android:theme"
+            android:exported="true" />
     </application>
 </manifest>

--- a/oss-licenses-plugin/testapp/app/src/main/AndroidManifest.xml
+++ b/oss-licenses-plugin/testapp/app/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
         </activity>
         <activity
             android:name="com.google.android.gms.oss.licenses.v2.OssLicensesMenuActivity"
+            android:theme="@style/Theme.CustomOssThemeV2"
+            tools:replace="android:theme"
             android:exported="true" />
         <activity
             android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"

--- a/oss-licenses-plugin/testapp/app/src/main/java/com/google/android/gms/oss/licenses/testapp/MainActivity.kt
+++ b/oss-licenses-plugin/testapp/app/src/main/java/com/google/android/gms/oss/licenses/testapp/MainActivity.kt
@@ -31,6 +31,8 @@ import androidx.compose.material3.Text
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.ui.graphics.Color
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity as V1Activity
 import com.google.android.gms.oss.licenses.v2.OssLicensesMenuActivity as V2Activity
 
@@ -44,15 +46,39 @@ class MainActivity : ComponentActivity() {
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
+                    Text("Library Version: ${getLibraryVersion()}")
+                    Spacer(modifier = Modifier.height(16.dp))
                     Button(onClick = { startActivity(Intent(this@MainActivity, V1Activity::class.java)) }) {
-                        Text("Launch V1 Licenses")
+                        Text("Launch V1 (XML Theme)")
                     }
                     Spacer(modifier = Modifier.height(16.dp))
-                    Button(onClick = { startActivity(Intent(this@MainActivity, V2Activity::class.java)) }) {
-                        Text("Launch V2 Licenses")
+                    Button(onClick = {
+                        val customColors = lightColorScheme(
+                            background = Color(0xFFE0F7FA), // Light Cyan
+                            surface = Color(0xFFE0F7FA),    // Light Cyan for TopAppBar
+                            onBackground = Color.Black,
+                            onSurface = Color.Black
+                        )
+                        V2Activity.setTheme(customColors, customColors, null)
+                        V2Activity.setActivityTitle("Custom Title from App")
+                        startActivity(Intent(this@MainActivity, V2Activity::class.java))
+                    }) {
+                        Text("Launch V2 (Compose Theme)")
                     }
                 }
             }
+        }
+    }
+
+    private fun getLibraryVersion(): String {
+        val id = resources.getIdentifier("version", "raw", packageName)
+        if (id == 0) return "UNKNOWN"
+        return try {
+            resources.openRawResource(id).use { inputStream ->
+                inputStream.bufferedReader().use { it.readText() }
+            }
+        } catch (e: Exception) {
+            "UNKNOWN"
         }
     }
 }

--- a/oss-licenses-plugin/testapp/app/src/main/java/com/google/android/gms/oss/licenses/testapp/MainActivity.kt
+++ b/oss-licenses-plugin/testapp/app/src/main/java/com/google/android/gms/oss/licenses/testapp/MainActivity.kt
@@ -65,6 +65,14 @@ class MainActivity : ComponentActivity() {
                     }) {
                         Text("Launch V2 (Compose Theme)")
                     }
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Button(onClick = {
+                        V2Activity.setTheme(null, null, null)
+                        V2Activity.setActivityTitle("Title from XML Theme")
+                        startActivity(Intent(this@MainActivity, V2Activity::class.java))
+                    }) {
+                        Text("Launch V2 (XML Theme)")
+                    }
                 }
             }
         }

--- a/oss-licenses-plugin/testapp/app/src/main/res/values/styles.xml
+++ b/oss-licenses-plugin/testapp/app/src/main/res/values/styles.xml
@@ -5,4 +5,9 @@
         <item name="colorPrimary">#E0F7FA</item> <!-- Light Cyan for Action Bar -->
         <item name="colorPrimaryDark">#B2EBF2</item> <!-- Darker Cyan for Status Bar if needed -->
     </style>
+    <style name="Theme.CustomOssThemeV2" parent="Theme.AppCompat.Light">
+        <item name="android:windowBackground">#FCE4EC</item> <!-- Light Pink -->
+        <item name="colorPrimary">#FCE4EC</item>
+        <item name="colorPrimaryDark">#F8BBD0</item>
+    </style>
 </resources>

--- a/oss-licenses-plugin/testapp/app/src/main/res/values/styles.xml
+++ b/oss-licenses-plugin/testapp/app/src/main/res/values/styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.CustomOssTheme" parent="Theme.AppCompat.Light">
+        <item name="android:windowBackground">#E0F7FA</item> <!-- Light Cyan -->
+        <item name="colorPrimary">#E0F7FA</item> <!-- Light Cyan for Action Bar -->
+        <item name="colorPrimaryDark">#B2EBF2</item> <!-- Darker Cyan for Status Bar if needed -->
+    </style>
+</resources>

--- a/oss-licenses-plugin/testapp/app/src/testRelease/java/com/google/android/gms/oss/licenses/testapp/OssLicensesV2CustomTitleTest.kt
+++ b/oss-licenses-plugin/testapp/app/src/testRelease/java/com/google/android/gms/oss/licenses/testapp/OssLicensesV2CustomTitleTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.gms.oss.licenses.testapp
+
+import android.content.Intent
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.gms.oss.licenses.v2.OssLicensesMenuActivity
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class OssLicensesV2CustomTitleTest {
+
+    @get:Rule val composeTestRule = createEmptyComposeRule()
+
+    @Test
+    fun testV2ActivityCustomTitleViaIntent() {
+        val customTitle = "My Custom Licenses Title"
+        val intent =
+            Intent(ApplicationProvider.getApplicationContext(), OssLicensesMenuActivity::class.java)
+                .apply { putExtra("title", customTitle) }
+
+        ActivityScenario.launch<OssLicensesMenuActivity>(intent).use {
+            composeTestRule.onNodeWithText(customTitle).assertExists()
+        }
+    }
+}

--- a/oss-licenses-plugin/testapp/app/src/testRelease/java/com/google/android/gms/oss/licenses/testapp/OssLicensesV2Test.kt
+++ b/oss-licenses-plugin/testapp/app/src/testRelease/java/com/google/android/gms/oss/licenses/testapp/OssLicensesV2Test.kt
@@ -23,7 +23,10 @@ import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import android.graphics.Color
+import android.util.TypedValue
 import com.google.android.gms.oss.licenses.v2.OssLicensesMenuActivity
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Ignore
 import org.junit.Rule
@@ -92,6 +95,26 @@ class OssLicensesV2Test {
 
         ActivityScenario.launch(OssLicensesMenuActivity::class.java).use {
             composeTestRule.onNodeWithText(customTitle).assertExists()
+        }
+    }
+
+    @Test
+    fun testV2ActivityUsesXmlThemeFallback() {
+        // Ensure no programmatic theme is set
+        OssLicensesMenuActivity.setTheme(null, null, null)
+
+        ActivityScenario.launch(OssLicensesMenuActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val typedValue = TypedValue()
+                val theme = activity.theme
+                val success = theme.resolveAttribute(android.R.attr.windowBackground, typedValue, true)
+                
+                assertTrue("Failed to resolve windowBackground attribute", success)
+                
+                // The expected color is #FCE4EC (Light Pink) defined in Theme.CustomOssThemeV2
+                val expectedColor = Color.parseColor("#FCE4EC")
+                assertEquals("Theme background color mismatch", expectedColor, typedValue.data)
+            }
         }
     }
 }

--- a/oss-licenses-plugin/testapp/app/src/testRelease/java/com/google/android/gms/oss/licenses/testapp/OssLicensesV2Test.kt
+++ b/oss-licenses-plugin/testapp/app/src/testRelease/java/com/google/android/gms/oss/licenses/testapp/OssLicensesV2Test.kt
@@ -83,18 +83,7 @@ class OssLicensesV2Test {
         }
     }
 
-    @Test
-    fun testV2ActivityCustomTitleViaIntent() {
-        val customTitle = "My Custom Licenses Title"
-        val intent =
-            Intent(ApplicationProvider.getApplicationContext(), OssLicensesMenuActivity::class.java)
-                .apply { putExtra("title", customTitle) }
 
-        ActivityScenario.launch<OssLicensesMenuActivity>(intent).use {
-            // The v2 library does not update activity.title, it only displays it in the Compose UI.
-            composeTestRule.onNodeWithText(customTitle).assertExists()
-        }
-    }
 
     @Test
     fun testV2ActivitySetActivityTitle() {

--- a/oss-licenses-plugin/testapp/app/src/testRelease/java/com/google/android/gms/oss/licenses/testapp/OssLicensesV2Test.kt
+++ b/oss-licenses-plugin/testapp/app/src/testRelease/java/com/google/android/gms/oss/licenses/testapp/OssLicensesV2Test.kt
@@ -95,4 +95,14 @@ class OssLicensesV2Test {
             composeTestRule.onNodeWithText(customTitle).assertExists()
         }
     }
+
+    @Test
+    fun testV2ActivitySetActivityTitle() {
+        val customTitle = "Test Title via API"
+        OssLicensesMenuActivity.setActivityTitle(customTitle)
+
+        ActivityScenario.launch(OssLicensesMenuActivity::class.java).use {
+            composeTestRule.onNodeWithText(customTitle).assertExists()
+        }
+    }
 }

--- a/oss-licenses-plugin/testapp/gradle.properties
+++ b/oss-licenses-plugin/testapp/gradle.properties
@@ -23,7 +23,7 @@ org.gradle.configuration-cache.problems=fail
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 
 # Plugin specific flags
-# This property silences warnings about vulnerable protobuf generated types 
+# This property silences warnings about vulnerable protobuf generated types
 # in older versions of AGP/Gradle.
 com.google.protobuf.use_unsafe_pre22_gencode=true
 

--- a/oss-licenses-plugin/testapp/gradle/libs.versions.toml
+++ b/oss-licenses-plugin/testapp/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ junit = "4.13.2"
 kotlin = "2.1.10"
 minSdk = "24"
 oss-licenses-plugin = "+"
-oss-licenses-library = "17.4.0"
+oss-licenses-library = "+" # Always use the latest available
 robolectric = "4.16.1"
 targetSdk = "36"
 

--- a/oss-licenses-plugin/testapp/settings.gradle.kts
+++ b/oss-licenses-plugin/testapp/settings.gradle.kts
@@ -60,18 +60,23 @@ plugins {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-        // Allow overriding the 'play-services-oss-licenses' runtime library with a local version.
-        // Usage: ./gradlew :app:test -PlibraryRepoPath=/path/to/your/mavenrepo
+        // // Allow overriding the 'play-services-oss-licenses' runtime library with a local version.
+        // // Usage: ./gradlew :app:test -PlibraryRepoPath=/path/to/your/mavenrepo
         val libraryRepo = providers.gradleProperty("libraryRepoPath").orNull
         if (libraryRepo != null) {
             println("Registering libraryRepoPath: $libraryRepo")
             exclusiveContent {
-                forRepository { maven { url = uri(libraryRepo) } }
+                forRepository {
+                    maven {
+                        url = uri(file(libraryRepo))
+                    }
+                }
                 filter {
                     includeModule("com.google.android.gms", "play-services-oss-licenses")
                 }
             }
         }
+
 
         google()
         mavenCentral()


### PR DESCRIPTION
- Declared V1 and V2 activities in manifest and added a custom XML theme.
- Added a task to extract the resolved library version and wired it to resources.
- Displayed the version on MainActivity and applied a custom Compose theme to V2.
- Added a unit test for the setActivityTitle API in V2.
- Updated the library version to "+" in libs.versions.toml.

Written by Antigravity