### PR TITLE
ci: modularize workflows and rename EndToEndTest to IntegrationTest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  # Detect which plugin directories a PR touches so we can skip unrelated jobs.
+  # On push-to-main and workflow_dispatch, downstream jobs ignore these outputs and always run.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      strict-version-matcher: ${{ steps.filter.outputs.strict-version-matcher }}
+      google-services: ${{ steps.filter.outputs.google-services }}
+      oss-licenses: ${{ steps.filter.outputs.oss-licenses }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # ratchet:dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            strict-version-matcher:
+              - 'strict-version-matcher-plugin/**'
+              - '.github/workflows/**'
+            google-services:
+              - 'google-services-plugin/**'
+              - '.github/workflows/**'
+            oss-licenses:
+              - 'oss-licenses-plugin/**'
+              - '.github/workflows/**'
+
+  # Linting (Runs on every PR)
+  lint:
+    uses: ./.github/workflows/lint.yml
+
+  # Independent Plugins
+  services-and-version-matcher:
+    needs: changes
+    # Only run if one of the plugins or the workflows changed
+    if: github.event_name != 'pull_request' || needs.changes.outputs.strict-version-matcher == 'true' || needs.changes.outputs.google-services == 'true'
+    uses: ./.github/workflows/services_and_version_matcher.yml
+    with:
+      run-google-services: ${{ github.event_name != 'pull_request' || needs.changes.outputs.google-services == 'true' }}
+      run-strict-version-matcher: ${{ github.event_name != 'pull_request' || needs.changes.outputs.strict-version-matcher == 'true' }}
+
+  # OSS Licenses Pipeline
+  oss-licenses:
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.oss-licenses == 'true'
+    uses: ./.github/workflows/oss-licenses.yml
+
+  # Aggregate status check
+  ci-success:
+    needs:
+      - changes
+      - lint
+      - services-and-version-matcher
+      - oss-licenses
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check upstream job results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS_JSON"
+          if echo "$NEEDS_JSON" | jq -e '[.[] | .result] | any(. == "failure" or . == "cancelled")' > /dev/null; then
+            echo "One or more upstream jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All upstream jobs succeeded or were skipped."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+on:
+  workflow_call: # This makes it "callable" by other workflows
+
+jobs:
+  lint-and-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # ratchet:gradle/actions/wrapper-validation@v6.1.0
+      - name: Lint GitHub Actions
+        uses: abcxyz/actions/.github/actions/lint-github-actions@3894a8d6a18b9aa159fe9092501d523d97f07110 # ratchet:abcxyz/actions/.github/actions/lint-github-actions@main
+      - name: Ratchet Check
+        uses: sethvargo/ratchet@27f7515b4648e179168f8f8ae2257636fdb03c48 # ratchet:sethvargo/ratchet@main
+        with:
+          files: .github/workflows/*.yml

--- a/.github/workflows/oss-licenses.yml
+++ b/.github/workflows/oss-licenses.yml
@@ -1,63 +1,11 @@
-# Perform a Gradle `build` which includes `assemble`, `check`, `test` of the projects.
+name: OSS Licenses CI
 
-name: CI
-
-# Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
-  push:
-    branches: [main]
-  pull_request:
+  workflow_call:
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # Check the integrity of the Gradle Wrapper executables and lint workflows
-  lint-and-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # ratchet:gradle/actions/wrapper-validation@v6.1.0
-      - name: Lint GitHub Actions
-        uses: abcxyz/actions/.github/actions/lint-github-actions@3894a8d6a18b9aa159fe9092501d523d97f07110 # ratchet:abcxyz/actions/.github/actions/lint-github-actions@main
-      - name: Ratchet Check
-        uses: sethvargo/ratchet@27f7515b4648e179168f8f8ae2257636fdb03c48 # ratchet:sethvargo/ratchet@main
-        with:
-          files: .github/workflows/*.yml
-
-  # Build the simple plugins (no special test infrastructure needed)
-  build:
-    needs: lint-and-check
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        project-dir:
-          - strict-version-matcher-plugin
-          - google-services-plugin
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5.2.0
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # ratchet:gradle/actions/setup-gradle@v6.1.0
-        with:
-          dependency-graph: generate-and-submit
-
-      - name: Perform a Gradle build
-        run: ./gradlew build
-        working-directory: ./${{ matrix.project-dir }}
-
   # Build and test the oss-licenses plugin, then publish for downstream jobs.
   oss-licenses-build:
-    needs: lint-and-check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
@@ -136,3 +84,22 @@ jobs:
           echo "$OUTPUT"
           echo "$OUTPUT" | grep -q "Configuration cache entry reused" || \
             { echo "::error::Configuration cache was NOT reused"; exit 1; }
+
+  # Aggregate status
+  oss-licenses-success:
+    needs:
+      - oss-licenses-build
+      - oss-licenses-testapp
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check upstream job results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS_JSON"
+          if echo "$NEEDS_JSON" | jq -e '[.[] | .result] | any(. == "failure" or . == "cancelled")' > /dev/null; then
+            echo "One or more upstream jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All upstream jobs succeeded or were skipped."

--- a/.github/workflows/services_and_version_matcher.yml
+++ b/.github/workflows/services_and_version_matcher.yml
@@ -1,0 +1,54 @@
+name: Services and Version Matcher CI
+
+on:
+  workflow_call:
+    inputs:
+      run-google-services:
+        type: boolean
+        default: true
+      run-strict-version-matcher:
+        type: boolean
+        default: true
+
+jobs:
+  build-strict-version-matcher:
+    if: inputs.run-strict-version-matcher
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5.2.0
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # ratchet:gradle/actions/setup-gradle@v6.1.0
+        with:
+          dependency-graph: generate-and-submit
+
+      - name: Perform a Gradle build
+        run: ./gradlew build
+        working-directory: ./strict-version-matcher-plugin
+
+  build-google-services:
+    if: inputs.run-google-services
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # ratchet:actions/setup-java@v5.2.0
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # ratchet:gradle/actions/setup-gradle@v6.1.0
+        with:
+          dependency-graph: generate-and-submit
+
+      - name: Perform a Gradle build
+        run: ./gradlew build
+        working-directory: ./google-services-plugin

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -39,7 +39,10 @@ This repository hosts Gradle plugins that improve the developer experience for t
 
 Managed via GitHub Actions with modern best practices:
 - **Workflows:**
-  - `main.yml`: The primary CI workflow. It includes a `lint-and-check` job (Gradle Wrapper validation, Actionlint, and Ratchet) and executes a build matrix that independently runs `assemble`, `check`, and `test` for each plugin project.
+  - `ci.yml`: Top-level coordinator. Uses `dorny/paths-filter` to detect which plugins changed and dispatches the matching specialist workflows via `workflow_call`. Aggregates their results in a `ci-success` gate job.
+  - `lint.yml`: Runs on every PR — Gradle Wrapper validation, Actionlint, and Ratchet pin check.
+  - `oss-licenses.yml`: Builds and tests the `oss-licenses-plugin`.
+  - `services_and_version_matcher.yml`: Builds and tests `google-services-plugin` and `strict-version-matcher-plugin`.
   - `generate_release_rcs.yml`: Handles the generation of release candidates.
 - **Security & Maintenance:**
   - **Version Pinning:** `sethvargo/ratchet` is used to enforce that all GitHub Actions are pinned to immutable SHA-256 checksums to protect against supply chain attacks.
@@ -65,7 +68,7 @@ Managed via GitHub Actions with modern best practices:
 
 ## 5. Engineering Standards
 
-- **Testing:** All changes must be verified with tests. `oss-licenses-plugin` requires verification against the full AGP/Gradle version matrix in `EndToEndTest.kt`.
+- **Testing:** All changes must be verified with tests. `oss-licenses-plugin` requires verification against the full AGP/Gradle version matrix in `IntegrationTest.kt`.
 - **Configuration Cache:** New tasks or refactors MUST maintain compatibility with the Gradle Configuration Cache. Use lazy properties and avoid direct project access during task execution.
 - **Commit Messages:** Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
   - Format: `<type>[optional scope]: <description>`

--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ Helps apps to display open source software licenses and notices.
 
 Required for firebase applications on android, converts google-services.json to a resource file for use by the app, and references the code in strict-version-matcher.
 
+## Security & Maintenance
+
+### Ratchet
+
+This project uses [Ratchet](https://github.com/sethvargo/ratchet) to ensure all GitHub Actions are pinned to immutable commit SHAs. This helps protect against supply chain attacks by ensuring that the actions used in CI/CD workflows are exactly the versions intended.
+
+Developers are encouraged to run `ratchet pin .github/workflows/*.yml` locally before submitting pull requests that introduce or update GitHub Actions.
+

--- a/oss-licenses-plugin/build.gradle.kts
+++ b/oss-licenses-plugin/build.gradle.kts
@@ -79,11 +79,11 @@ tasks.withType<Test>().configureEach {
     ).withPathSensitivity(PathSensitivity.RELATIVE).withPropertyName("repo")
 
     val localVersion = project.version.toString()
-    systemProperties["plugin_version"] = localVersion // value used by EndToEndTest.kt
-    systemProperties["testkit_path"] = layout.buildDirectory.dir("testkit").get().asFile.absolutePath // value used by EndToEndTest.kt
+    systemProperties["plugin_version"] = localVersion // value used by IntegrationTest.kt
+    systemProperties["testkit_path"] = layout.buildDirectory.dir("testkit").get().asFile.absolutePath // value used by IntegrationTest.kt
     doFirst {
         // Inside doFirst to make sure that absolute path is not considered to be input to the task
-        systemProperties["repo_path"] = localRepo.get().asFile.absolutePath // value used by EndToEndTest.kt
+        systemProperties["repo_path"] = localRepo.get().asFile.absolutePath // value used by IntegrationTest.kt
     }
     minHeapSize = "512m"
     maxHeapSize = "2g"

--- a/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/IntegrationTest.kt
+++ b/oss-licenses-plugin/src/test/java/com/google/android/gms/oss/licenses/plugin/IntegrationTest.kt
@@ -25,7 +25,7 @@ import org.junit.rules.TemporaryFolder
 import org.junit.Rule
 import java.io.File
 
-abstract class EndToEndTest(private val agpVersion: String, private val gradleVersion: String) {
+abstract class IntegrationTest(private val agpVersion: String, private val gradleVersion: String) {
 
     @get:Rule
     val tempDirectory: TemporaryFolder = TemporaryFolder()
@@ -365,12 +365,12 @@ abstract class EndToEndTest(private val agpVersion: String, private val gradleVe
     }
 }
 
-class EndToEndTest_AGP74_G75 : EndToEndTest("7.4.2", "7.5.1")
-class EndToEndTest_AGP80_G80 : EndToEndTest("8.0.2", "8.0.2")
-class EndToEndTest_AGP87_G89 : EndToEndTest("8.7.3", "8.9")
-class EndToEndTest_AGP812_G814 : EndToEndTest("8.12.2", "8.14.1")
-class EndToEndTest_AGP_STABLE_90_G90 : EndToEndTest("9.0.1", "9.1.0")
-class EndToEndTest_AGP_ALPHA_92_G94 : EndToEndTest("9.2.0-alpha02", "9.4.0")
+class IntegrationTest_AGP74_G75 : IntegrationTest("7.4.2", "7.5.1")
+class IntegrationTest_AGP80_G80 : IntegrationTest("8.0.2", "8.0.2")
+class IntegrationTest_AGP87_G89 : IntegrationTest("8.7.3", "8.9")
+class IntegrationTest_AGP812_G814 : IntegrationTest("8.12.2", "8.14.1")
+class IntegrationTest_AGP_STABLE_90_G90 : IntegrationTest("9.0.1", "9.1.0")
+class IntegrationTest_AGP_ALPHA_92_G94 : IntegrationTest("9.2.0-alpha02", "9.4.0")
 
 private fun expectedDependenciesJson(builtInKotlinEnabled: Boolean, agpVersion: String) = """[
     {


### PR DESCRIPTION
## Summary

Part 1 of a stacked testing infrastructure update for `oss-licenses-plugin`.

## Key changes

- Modularized the GitHub Actions CI into specialist workflows (`lint.yml`, `oss-licenses.yml`, `services_and_version_matcher.yml`) so each plugin's pipeline can run independently and in parallel.
- Added a `ci.yml` coordinator that fans out to the specialist workflows using path-based filtering so unrelated changes don't spin up unrelated jobs.
- Renamed `EndToEndTest.kt` to `IntegrationTest.kt` in preparation for a new dedicated end-to-end test suite landing in a later PR in the stack.
- Swept stale `EndToEndTest.kt` comments in `oss-licenses-plugin/build.gradle.kts` and `GEMINI.md` that were missed by the initial rename.
- Bumped the ratchet pins for `abcxyz/actions/lint-github-actions` and `sethvargo/ratchet` on `lint.yml`.

## Test plan

- [x] `./gradlew check` on `oss-licenses-plugin` passes locally.
- [ ] CI workflow_call runs green across all specialist jobs.
