### PR TITLE
docs(oss-licenses): trim README to avoid duplication with public docs

### DIFF
--- a/oss-licenses-plugin/README.md
+++ b/oss-licenses-plugin/README.md
@@ -1,6 +1,22 @@
 # OSS Licenses Gradle Plugin
 
-This Gradle plugin scans the POM dependencies of a project at compile time and embeds license information in the final app APK.
+This Gradle plugin scans the POM dependencies of a project at compile time.
+When a Maven POM exists for a direct dependency of the app, the plugin processes
+the [`<licenses>`](https://maven.apache.org/pom.html#Licenses) element and
+embeds the link and title of each license in an Android asset in the final app
+APK.
+
+For Google Play services dependencies, the license info is gathered from
+third_party_licenses.json and third_party_licenses.txt files in the distributed
+.aar.
+
+The plugin will generate two text files based on the gathered licenses info:
+
+  * third_party_licenses
+  * third_party_licenses_metadata
+
+and registers them as raw resources so that it can be consumed by the
+play-services-oss-licenses library.
 
 For detailed instructions on how to add the plugin to your project, configure dependencies, and display license information using the SDK, please refer to the official documentation:
 

--- a/oss-licenses-plugin/README.md
+++ b/oss-licenses-plugin/README.md
@@ -1,81 +1,11 @@
 # OSS Licenses Gradle Plugin
 
-This Gradle plugin scans the POM dependencies of a project at compile time.
-When a Maven POM exists for a direct dependency of the app, the plugin processes
-the [`<licenses>`](https://maven.apache.org/pom.html#Licenses) element and
-embeds the link and title of each license in an Android asset in the final app
-APK.
+This Gradle plugin scans the POM dependencies of a project at compile time and embeds license information in the final app APK.
 
-For Google Play services dependencies, the license info is gathered from
-third_party_licenses.json and third_party_licenses.txt files in the distributed
-.aar.
+For detailed instructions on how to add the plugin to your project, configure dependencies, and display license information using the SDK, please refer to the official documentation:
 
-The plugin will generate two text files based on the gathered licenses info:
+👉 **[Include open source notices](https://developers.google.com/android/guides/opensource)**
 
-  * third_party_licenses
-  * third_party_licenses_metadata
+## Source Code and Contributing
 
-and registers them as raw resources so that it can be consumed by the
-play-services-oss-licenses library.
-
-## To Use
-
-### Add the Gradle plugin
-
-In your root-level `settings.gradle.kts` make sure you are using the
-[Google Maven repository](https://developer.android.com/studio/build/dependencies#google-maven):
-
-```kotlin
-pluginManagement {
-    repositories {
-        google()
-    }
-}
-```
-
-In your app-level `build.gradle.kts`, apply the plugin by adding the following line
-under the existing `id("com.android.application")` at the top of the
-file:
-
-```kotlin
-plugins {
-    id("com.google.android.gms.oss-licenses-plugin") version "0.11.0"
-}
-```
-
-### Add the library to your app
-
-In the `dependencies` section of your app-level `build.gradle.kts`, add a dependency
-on the `oss-licenses` library:
-
-```kotlin
-implementation("com.google.android.gms:play-services-oss-licenses:17.0.0")
-```
-
-### Displaying license information
-
-When the application builds, the Gradle plugin will process the licenses and
-add them to the app resources. To easily display them you can trigger an
-activity provided by the `play-services-oss-licenses` library at an appropriate
-point in your app:
-
-```java
-import com.google.android.gms.oss.licenses.OssLicensesMenuActivity;
-
-// ...
-
-// When the user selects an option to see the licenses:
-startActivity(new Intent(this, OssLicensesMenuActivity.class));
-```
-
-This will display a list of open source libraries that are compiled into the
-app, whether part of Google Play services or not. Tapping the library name will
-display additional license information for that library.
-
-### Setting the `Activity` title
-
-You can also set the title of the displayed activity:
-
-```java
-OssLicensesMenuActivity.setActivityTitle(getString(R.string.custom_license_title));
-```
+The source code for this plugin is hosted in this repository. For contributing guidelines or to report issues, please see the root project documentation.


### PR DESCRIPTION
This PR trims down the local README.md file to avoid duplication with public documentation and remove out-of-date information, as suggested by Joey.