### PR TITLE
feat(oss-licenses): Prep for version 0.12.0 release

### DIFF
--- a/oss-licenses-plugin/build.gradle.kts
+++ b/oss-licenses-plugin/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 group = "com.google.android.gms"
-version = "0.11.0"
+version = "0.12.0"
 
 repositories {
     google()

--- a/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
+++ b/oss-licenses-plugin/src/main/groovy/com/google/android/gms/oss/licenses/plugin/LicensesTask.groovy
@@ -151,7 +151,7 @@ abstract class LicensesTask extends DefaultTask {
         artifactInfoSet.asImmutable()
     }
 
-    private void addDebugLicense() {
+    protected void addDebugLicense() {
         appendDependency(
                 ABSENT_DEPENDENCY_KEY,
                 ABSENT_DEPENDENCY_TEXT.getBytes(UTF_8)


### PR DESCRIPTION
## Summary
This PR prepares the 0.12.0 release of the `oss-licenses-plugin`.

## Key Changes
- Bumped version to **0.12.0**.
- **Re-applied visibility fix** for `addDebugLicense` (changed from `private` to `protected`). This resolves a regression introduced in #381 that caused `Could not find method addDebugLicense()` errors on `debug` build variants using product flavors (#394).

## Test Plan
- [x] `./gradlew :oss-licenses-plugin:test` passes locally.
- [ ] CI builds and tests against the full AGP/Gradle matrix.