### PR TITLE
Add support for reCAPTCHA site key

### DIFF
--- a/google-services-plugin/src/main/kotlin/com/google/gms/googleservices/GoogleServicesTask.kt
+++ b/google-services-plugin/src/main/kotlin/com/google/gms/googleservices/GoogleServicesTask.kt
@@ -261,8 +261,8 @@ abstract class GoogleServicesTask : DefaultTask() {
   }
 
     fun FirebaseClientData.handleSiteKey(resValues: MutableMap<String, String?>) {
-        this.getAsJsonPrimitive("recaptcha_enterprise_site_key")?.let {
-            resValues["recaptcha_enterprise_site_key"] = it.asString
+        this.getAsJsonPrimitive("recaptcha_site_key")?.let {
+            resValues["recaptcha_site_key"] = it.asString
         }
     }
 

--- a/google-services-plugin/src/main/kotlin/com/google/gms/googleservices/GoogleServicesTask.kt
+++ b/google-services-plugin/src/main/kotlin/com/google/gms/googleservices/GoogleServicesTask.kt
@@ -65,8 +65,8 @@ abstract class GoogleServicesTask : DefaultTask() {
     if (jsonFiles.isEmpty()) {
       val message =
           """
-                File $JSON_FILE_NAME is missing. 
-                The Google Services Plugin cannot function without it. 
+                File $JSON_FILE_NAME is missing.
+                The Google Services Plugin cannot function without it.
                 Searched locations: ${
                 googleServicesJsonFiles.get().joinToString { it.absolutePath }
             }
@@ -109,6 +109,7 @@ abstract class GoogleServicesTask : DefaultTask() {
       handleGoogleApiKey(resValues)
       handleGoogleAppId(resValues)
       handleWebClientId(resValues)
+        handleSiteKey(resValues)
     }
         ?: throw GradleException(
             "No matching client found for package name '${applicationId.get()}' in ${quickstartFile.path}")
@@ -208,7 +209,7 @@ abstract class GoogleServicesTask : DefaultTask() {
           """
                     <?xml version="1.0" encoding="utf-8"?>
                     <resources>
-                    
+
                 """
               .trimIndent())
       for ((name, value) in values) {
@@ -257,6 +258,14 @@ abstract class GoogleServicesTask : DefaultTask() {
         return
       }
     }
+  }
+
+  fun FirebaseClientData.handleSiteKey(resValues: MutableMap<String, String?>) {
+    if (!this.has("recaptcha_enterprise_site_key")) {
+      return
+    }
+    val siteKey = this.getAsJsonPrimitive("recaptcha_enterprise_site_key")
+    resValues["recaptcha_enterprise_site_key"] = siteKey.asString
   }
 
   /**

--- a/google-services-plugin/src/main/kotlin/com/google/gms/googleservices/GoogleServicesTask.kt
+++ b/google-services-plugin/src/main/kotlin/com/google/gms/googleservices/GoogleServicesTask.kt
@@ -260,13 +260,11 @@ abstract class GoogleServicesTask : DefaultTask() {
     }
   }
 
-  fun FirebaseClientData.handleSiteKey(resValues: MutableMap<String, String?>) {
-    if (!this.has("recaptcha_enterprise_site_key")) {
-      return
+    fun FirebaseClientData.handleSiteKey(resValues: MutableMap<String, String?>) {
+        this.getAsJsonPrimitive("recaptcha_enterprise_site_key")?.let {
+            resValues["recaptcha_enterprise_site_key"] = it.asString
+        }
     }
-    val siteKey = this.getAsJsonPrimitive("recaptcha_enterprise_site_key")
-    resValues["recaptcha_enterprise_site_key"] = siteKey.asString
-  }
 
   /**
    * Handle a client object for analytics (@xml/global_tracker)

--- a/google-services-plugin/src/test/testData/project1-expected/processFreeOneDebugGoogleServices/values/values.xml
+++ b/google-services-plugin/src/test/testData/project1-expected/processFreeOneDebugGoogleServices/values/values.xml
@@ -7,5 +7,5 @@
     <string name="google_app_id" translatable="false">1:123456789000:android:f1bf012572b04063</string>
     <string name="google_crash_reporting_api_key" translatable="false">AIzbSzCn1N6LWIe6wthYyrgUUSAlUsdqMb-wvTo</string>
     <string name="project_id" translatable="false">mockproject-1234</string>
-    <string name="recaptcha_enterprise_site_key" translatable="false">6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00</string>
+    <string name="recaptcha_site_key" translatable="false">6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00</string>
 </resources>

--- a/google-services-plugin/src/test/testData/project1-expected/processFreeOneDebugGoogleServices/values/values.xml
+++ b/google-services-plugin/src/test/testData/project1-expected/processFreeOneDebugGoogleServices/values/values.xml
@@ -7,4 +7,5 @@
     <string name="google_app_id" translatable="false">1:123456789000:android:f1bf012572b04063</string>
     <string name="google_crash_reporting_api_key" translatable="false">AIzbSzCn1N6LWIe6wthYyrgUUSAlUsdqMb-wvTo</string>
     <string name="project_id" translatable="false">mockproject-1234</string>
+    <string name="recaptcha_enterprise_site_key" translatable="false">6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00</string>
 </resources>

--- a/google-services-plugin/src/test/testData/project1-expected/processFreeTwoDebugGoogleServices/values/values.xml
+++ b/google-services-plugin/src/test/testData/project1-expected/processFreeTwoDebugGoogleServices/values/values.xml
@@ -7,5 +7,5 @@
     <string name="google_app_id" translatable="false">1:123456789000:android:f1bf012572b04063</string>
     <string name="google_crash_reporting_api_key" translatable="false">AIzbSzCn1N6LWIe6wthYyrgUUSAlUsdqMb-wvTo</string>
     <string name="project_id" translatable="false">mockproject-1234</string>
-    <string name="recaptcha_enterprise_site_key" translatable="false">6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00</string>
+    <string name="recaptcha_site_key" translatable="false">6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00</string>
 </resources>

--- a/google-services-plugin/src/test/testData/project1-expected/processFreeTwoDebugGoogleServices/values/values.xml
+++ b/google-services-plugin/src/test/testData/project1-expected/processFreeTwoDebugGoogleServices/values/values.xml
@@ -7,4 +7,5 @@
     <string name="google_app_id" translatable="false">1:123456789000:android:f1bf012572b04063</string>
     <string name="google_crash_reporting_api_key" translatable="false">AIzbSzCn1N6LWIe6wthYyrgUUSAlUsdqMb-wvTo</string>
     <string name="project_id" translatable="false">mockproject-1234</string>
+    <string name="recaptcha_enterprise_site_key" translatable="false">6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00</string>
 </resources>

--- a/google-services-plugin/src/test/testData/project1-expected/processPaidOneDebugGoogleServices/values/values.xml
+++ b/google-services-plugin/src/test/testData/project1-expected/processPaidOneDebugGoogleServices/values/values.xml
@@ -7,5 +7,5 @@
     <string name="google_app_id" translatable="false">1:123456789000:android:f1bf012572b04063</string>
     <string name="google_crash_reporting_api_key" translatable="false">AIzbSzCn1N6LWIe6wthYyrgUUSAlUsdqMb-wvTo</string>
     <string name="project_id" translatable="false">mockproject-1234</string>
-    <string name="recaptcha_enterprise_site_key" translatable="false">6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00</string>
+    <string name="recaptcha_site_key" translatable="false">6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00</string>
 </resources>

--- a/google-services-plugin/src/test/testData/project1-expected/processPaidOneDebugGoogleServices/values/values.xml
+++ b/google-services-plugin/src/test/testData/project1-expected/processPaidOneDebugGoogleServices/values/values.xml
@@ -7,4 +7,5 @@
     <string name="google_app_id" translatable="false">1:123456789000:android:f1bf012572b04063</string>
     <string name="google_crash_reporting_api_key" translatable="false">AIzbSzCn1N6LWIe6wthYyrgUUSAlUsdqMb-wvTo</string>
     <string name="project_id" translatable="false">mockproject-1234</string>
+    <string name="recaptcha_enterprise_site_key" translatable="false">6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00</string>
 </resources>

--- a/google-services-plugin/src/test/testData/project1-expected/processPaidTwoDebugGoogleServices/values/values.xml
+++ b/google-services-plugin/src/test/testData/project1-expected/processPaidTwoDebugGoogleServices/values/values.xml
@@ -7,5 +7,5 @@
     <string name="google_app_id" translatable="false">1:123456789000:android:f1bf012572b04063</string>
     <string name="google_crash_reporting_api_key" translatable="false">AIzbSzCn1N6LWIe6wthYyrgUUSAlUsdqMb-wvTo</string>
     <string name="project_id" translatable="false">mockproject-1234</string>
-    <string name="recaptcha_enterprise_site_key" translatable="false">6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00</string>
+    <string name="recaptcha_site_key" translatable="false">6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00</string>
 </resources>

--- a/google-services-plugin/src/test/testData/project1-expected/processPaidTwoDebugGoogleServices/values/values.xml
+++ b/google-services-plugin/src/test/testData/project1-expected/processPaidTwoDebugGoogleServices/values/values.xml
@@ -7,4 +7,5 @@
     <string name="google_app_id" translatable="false">1:123456789000:android:f1bf012572b04063</string>
     <string name="google_crash_reporting_api_key" translatable="false">AIzbSzCn1N6LWIe6wthYyrgUUSAlUsdqMb-wvTo</string>
     <string name="project_id" translatable="false">mockproject-1234</string>
+    <string name="recaptcha_enterprise_site_key" translatable="false">6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00</string>
 </resources>

--- a/google-services-plugin/src/test/testData/project1/app/google-services.json
+++ b/google-services-plugin/src/test/testData/project1/app/google-services.json
@@ -957,7 +957,7 @@
           "test_interstitial_ad_unit_id": "ca-app-pub-3940256099942544/1033173712"
         }
       },
-      "recaptcha_enterprise_site_key": "6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00"
+      "recaptcha_site_key": "6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00"
     }
   ],
   "client_info": [],

--- a/google-services-plugin/src/test/testData/project1/app/google-services.json
+++ b/google-services-plugin/src/test/testData/project1/app/google-services.json
@@ -956,7 +956,8 @@
           "test_banner_ad_unit_id": "ca-app-pub-3940256099942544/6300978111",
           "test_interstitial_ad_unit_id": "ca-app-pub-3940256099942544/1033173712"
         }
-      }
+      },
+      "recaptcha_enterprise_site_key": "6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00"
     }
   ],
   "client_info": [],


### PR DESCRIPTION
Updated GoogleServiesTask to extract the `recaptcha_site_key` from the google-services.json file and include it in the generated `resources.xml` file.