### PR TITLE
[GoogleServicesPlugin] Bump version

### DIFF
--- a/google-services-plugin/build.gradle.kts
+++ b/google-services-plugin/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "com.google.gms"
-version = "4.4.4"
+version = "4.5.0"
 
 dependencies {
     compileOnly("com.android.tools.build:gradle-api:7.3.0")


### PR DESCRIPTION
The next released version should be a minor version bump since the plugin now supports a new field in the `google-services.json` file.