### PR TITLE
chore: revert dependabot updates for google-services and strict-version-matcher plugins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,22 +32,4 @@ updates:
         patterns:
           - "*"
 
-  - package-ecosystem: "gradle"
-    directory: "/google-services-plugin"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 1
-    groups:
-      all-dependencies:
-        patterns:
-          - "*"
 
-  - package-ecosystem: "gradle"
-    directory: "/strict-version-matcher-plugin"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 1
-    groups:
-      all-dependencies:
-        patterns:
-          - "*"


### PR DESCRIPTION
Written by Antigravity
