### PR TITLE
build(deps): update AGP and Gradle testing matrix to latest releases

### DIFF
--- a/.github/workflows/oss-licenses.yml
+++ b/.github/workflows/oss-licenses.yml
@@ -52,7 +52,7 @@ jobs:
       # Keep this list in sync with the integrationOnlyVersions + e2eVersions maps in
       # oss-licenses-plugin/build.gradle.kts.
       matrix:
-        agp-version-key: [AGP74, AGP87, AGP812, AGP_STABLE, AGP_ALPHA]
+        agp-version-key: [AGP74, AGP87, AGP813, AGP_STABLE, AGP_ALPHA]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
 
@@ -93,7 +93,7 @@ jobs:
       # Keep this list in sync with the e2eVersions map in
       # oss-licenses-plugin/build.gradle.kts.
       matrix:
-        agp-version-key: [AGP812, AGP_STABLE, AGP_ALPHA]
+        agp-version-key: [AGP813, AGP_STABLE, AGP_ALPHA]
     env:
       ANDROID_USER_HOME: /home/runner/.android
     steps:

--- a/oss-licenses-plugin/build.gradle.kts
+++ b/oss-licenses-plugin/build.gradle.kts
@@ -76,9 +76,9 @@ dependencies {
 // E2E versions are a subset of the integration versions. Integration tests extend the E2E set
 // with older AGP versions to ensure broad backward compatibility.
 val e2eVersions = mapOf(
-    "AGP812"      to ("8.12.2" to "8.14.1"),       // latest stable 8.x
-    "AGP_STABLE"  to ("9.1.1" to "9.4.1"),         // latest stable 9.x
-    "AGP_ALPHA"   to ("9.3.0-alpha01" to "9.5.0-rc-3"), // latest alpha
+    "AGP813"      to ("8.13.2" to "8.14.1"),       // latest stable 8.x (bumped from 8.12.2)
+    "AGP_STABLE"  to ("9.2.1" to "9.6.0"),         // latest stable 9.x using latest stable Gradle (9.6.0)
+    "AGP_ALPHA"   to ("9.4.0-alpha01" to "9.6.0"), // latest alpha using latest stable Gradle (no active RC; satisfies >= 9.5.0)
 )
 val integrationOnlyVersions = mapOf(
     "AGP74" to ("7.4.2" to "7.5.1"), // oldest supported

--- a/oss-licenses-plugin/src/e2eTest/kotlin/com/google/android/gms/oss/licenses/plugin/EndToEndTest.kt
+++ b/oss-licenses-plugin/src/e2eTest/kotlin/com/google/android/gms/oss/licenses/plugin/EndToEndTest.kt
@@ -31,8 +31,8 @@ import java.io.File
 abstract class EndToEndTest {
 
     // AGP and Gradle versions are defined in build.gradle.kts (single source of truth) and injected
-    // as system properties keyed by class name. E.g., EndToEndTest_AGP812 reads the system
-    // properties "EndToEndTest_AGP812.agpVersion" and "EndToEndTest_AGP812.gradleVersion".
+    // as system properties keyed by class name. E.g., EndToEndTest_AGP813 reads the system
+    // properties "EndToEndTest_AGP813.agpVersion" and "EndToEndTest_AGP813.gradleVersion".
     // To add a new version: add an entry to e2eVersions in build.gradle.kts and a subclass here
     // whose name matches the map key (prefixed with "EndToEndTest_").
     private val agpVersion: String = System.getProperty("${javaClass.simpleName}.agpVersion")
@@ -163,6 +163,6 @@ abstract class EndToEndTest {
 }
 
 // Due to the dependency requirements of the library, we can only test with recent versions of AGP
-class EndToEndTest_AGP812 : EndToEndTest()
+class EndToEndTest_AGP813 : EndToEndTest()
 class EndToEndTest_AGP_STABLE : EndToEndTest()
 class EndToEndTest_AGP_ALPHA : EndToEndTest()

--- a/oss-licenses-plugin/src/integrationTest/kotlin/com/google/android/gms/oss/licenses/plugin/IntegrationTest.kt
+++ b/oss-licenses-plugin/src/integrationTest/kotlin/com/google/android/gms/oss/licenses/plugin/IntegrationTest.kt
@@ -386,7 +386,7 @@ abstract class IntegrationTest {
 
 class IntegrationTest_AGP74 : IntegrationTest()
 class IntegrationTest_AGP87 : IntegrationTest()
-class IntegrationTest_AGP812 : IntegrationTest()
+class IntegrationTest_AGP813 : IntegrationTest()
 class IntegrationTest_AGP_STABLE : IntegrationTest()
 class IntegrationTest_AGP_ALPHA : IntegrationTest()
 


### PR DESCRIPTION
This pull request updates the stable, alpha, and 8.x Android Gradle Plugin (AGP) and Gradle runner versions in our centralized testing matrix to align with the latest releases on Google Maven and Gradle services.

### 🛠️ Key Changes:
1.  **AGP Stable 8.x Upgrade:** Transitioned the `AGP812` version key to **`AGP813`** (pointing to **AGP `8.13.2`** and **Gradle `8.14.1`**).
2.  **AGP Stable 9.x Upgrade (`AGP_STABLE`):** Bumped to **AGP `9.2.1`** (latest stable 9.x) and **Gradle `9.6.0`** (latest stable Gradle).
3.  **AGP Alpha 9.x Upgrade (`AGP_ALPHA`):** Bumped to **AGP `9.4.0-alpha01`** (latest alpha 9.x).
4.  **Gradle Mismatch Resolution:** Mapped the Gradle runner for both stable and alpha 9.x lines to **`9.6.0`**. This cleanly resolves the strict `com.android.internal.version-check` constraint introduced in AGP `9.4.0-alpha01` (which requires `Gradle >= 9.5.0` and failed when run with `9.5.0-rc-3`).
5.  **Subclass Alignment:** Renamed all corresponding integration and E2E test subclasses (e.g. `IntegrationTest_AGP812` ➔ `IntegrationTest_AGP813`) to ensure perfect matrix consistency.

---

### 🧪 Verification & Local Test Results:
All tests were run locally on the branch after merging the latest `main` (which contains the namespaced licensing clean-ups from PR #427):
*   **Command:** `./gradlew check`
*   **Result:** **BUILD SUCCESSFUL** (completed in 2m 53s).
*   **Status:** All 33 tests across unit, integration, and E2E matrices passed perfectly (including E2E checks on AGP `8.13.2`, `9.2.1`, and `9.4.0-alpha01` running on Gradle `9.6.0`).

Written by Jetski