### PR TITLE
ci: harden github actions workflows against zizmor warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,6 @@ jobs:
 
   # Aggregate status check
   ci-success:
-    name: CI Status Gate
     needs:
       - changes
       - lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,19 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: read # Required by dorny/paths-filter to fetch PR file diffs
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   # Detect which plugin directories a PR touches so we can skip unrelated jobs.
   # On push-to-main and workflow_dispatch, downstream jobs ignore these outputs and always run.
   changes:
+    name: Detect changes
     runs-on: ubuntu-latest
     outputs:
       strict-version-matcher: ${{ steps.filter.outputs.strict-version-matcher }}
@@ -17,6 +26,8 @@ jobs:
       oss-licenses: ${{ steps.filter.outputs.oss-licenses }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # ratchet:dorny/paths-filter@v4.0.1
         id: filter
         with:
@@ -53,6 +64,7 @@ jobs:
 
   # Aggregate status check
   ci-success:
+    name: CI Status Gate
     needs:
       - changes
       - lint

--- a/.github/workflows/generate_release_rcs.yml
+++ b/.github/workflows/generate_release_rcs.yml
@@ -12,10 +12,18 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
   build:
+    name: Build and publish release artifacts
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -31,6 +39,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,11 +3,17 @@ name: Lint
 on:
   workflow_call: # This makes it "callable" by other workflows
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-check:
+    name: Run linters and checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
       - name: Validate Gradle Wrapper
         uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # ratchet:gradle/actions/wrapper-validation@v6.2.0
       - name: Lint GitHub Actions

--- a/.github/workflows/oss-licenses.yml
+++ b/.github/workflows/oss-licenses.yml
@@ -3,12 +3,18 @@ name: OSS Licenses CI
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   # Build and test the oss-licenses plugin, then publish for downstream jobs.
   oss-licenses-build:
+    name: Build and package OSS licenses plugin
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # ratchet:actions/setup-java@v5.3.0
@@ -45,6 +51,7 @@ jobs:
 
   # Run the version-matricked integration tests in parallel.
   oss-licenses-integration-test:
+    name: Run integration tests
     needs: oss-licenses-build
     runs-on: ubuntu-latest
     strategy:
@@ -55,6 +62,8 @@ jobs:
         agp-version-key: [AGP74, AGP87, AGP813, AGP_STABLE, AGP_ALPHA]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Download local repo artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8.0.1
@@ -80,12 +89,15 @@ jobs:
 
       - name: Run Integration Test (${{ matrix.agp-version-key }})
         # Skip the local-repo publish here because we want to use the pre-built plugin from the artifact.
-        run: ./gradlew integrationTestTask --tests "com.google.android.gms.oss.licenses.plugin.IntegrationTest_${{ matrix.agp-version-key }}" -x publishAllPublicationsToLocalRepository
+        env:
+          AGP_VERSION: ${{ matrix.agp-version-key }}
+        run: ./gradlew integrationTestTask --tests "com.google.android.gms.oss.licenses.plugin.IntegrationTest_${AGP_VERSION}" -x publishAllPublicationsToLocalRepository
         working-directory: ./oss-licenses-plugin
 
   # Run end-to-end tests: build the full testapp against the AGP/Gradle version matrix.
   # Uses the locally-published plugin from oss-licenses-build via -PusePublishedPluginFrom.
   oss-licenses-e2e:
+    name: Run end-to-end tests
     needs: oss-licenses-build
     runs-on: ubuntu-latest
     strategy:
@@ -98,6 +110,8 @@ jobs:
       ANDROID_USER_HOME: /home/runner/.android
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Download local repo artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8.0.1
@@ -128,11 +142,14 @@ jobs:
 
       - name: Build testapp (verify ${{ matrix.agp-version-key }})
         # Skip the local-repo publish here because we want to use the pre-built plugin from the artifact.
-        run: ./gradlew e2eTestTask --tests "com.google.android.gms.oss.licenses.plugin.EndToEndTest_${{ matrix.agp-version-key }}" -x publishAllPublicationsToLocalRepository
+        env:
+          AGP_VERSION: ${{ matrix.agp-version-key }}
+        run: ./gradlew e2eTestTask --tests "com.google.android.gms.oss.licenses.plugin.EndToEndTest_${AGP_VERSION}" -x publishAllPublicationsToLocalRepository
         working-directory: oss-licenses-plugin
 
   # Aggregate status
   oss-licenses-success:
+    name: OSS Licenses Status Gate
     needs:
       - oss-licenses-build
       - oss-licenses-integration-test

--- a/.github/workflows/services_and_version_matcher.yml
+++ b/.github/workflows/services_and_version_matcher.yml
@@ -10,12 +10,18 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 jobs:
   build-strict-version-matcher:
+    name: Build strict version matcher plugin
     if: inputs.run-strict-version-matcher
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # ratchet:actions/setup-java@v5.3.0
@@ -33,10 +39,13 @@ jobs:
         working-directory: ./strict-version-matcher-plugin
 
   build-google-services:
+    name: Build google services plugin
     if: inputs.run-google-services
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # ratchet:actions/setup-java@v5.3.0


### PR DESCRIPTION
### Description

This PR implements security hardening across all GitHub Actions workflows in the repository to align with modern security best practices and prevent potential supply chain or CI/CD vulnerabilities.

### Changes

1. **Enforce Principle of Least Privilege (Granular Permissions)**:
   * Added explicit top-level `permissions` blocks to all workflows to restrict the default scope of the `GITHUB_TOKEN`.
   * Restricted all workflows to `contents: read` by default.
   * Granted `pull-requests: read` only to the `CI` workflow, which is specifically required by `dorny/paths-filter` to fetch file diffs via the GitHub API for pull requests.

2. **Disable Git Credential Persistence**:
   * Set `persist-credentials: false` on all `actions/checkout` steps across all 5 workflows. This ensures the `GITHUB_TOKEN` is not stored in the runner's local Git configuration, preventing subsequent build steps or third-party actions from accessing it.

3. **Add Concurrency Controls**:
   * Configured top-level `concurrency` groups in entrypoint workflows (`ci.yml` and `generate_release_rcs.yml`) to automatically cancel in-progress runs when new commits are pushed to the same branch or pull request.

4. **Secure Matrix Variable Expansion (Shell Injection Prevention)**:
   * Updated `oss-licenses.yml` to pass matrix variables (e.g., `${{ matrix.agp-version-key }}`) into steps via step-level `env` blocks instead of interpolating them directly into inline shell script `run` strings. This ensures the values are handled safely as data rather than executable code.

5. **Improve UI Readability**:
   * Added descriptive, human-readable `name:` fields to all jobs across the workflows to improve the structure and readability of the GitHub Actions run UI.

### Verification

* Verified locally using the `zizmor` static analysis linter with the most sensitive auditing profile (`--persona=auditor --min-severity=informational --min-confidence=low`), reporting **0 findings**.
