### PR TITLE
chore(oss-licenses): bump version to 0.13.0

### DIFF
--- a/oss-licenses-plugin/build.gradle.kts
+++ b/oss-licenses-plugin/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 group = "com.google.android.gms"
-version = "0.12.0"
+version = "0.13.0"
 
 repositories {
     google()


### PR DESCRIPTION
Bumps the version of the OSS licenses plugin to 0.13.0 for the M183 release.