### PR TITLE
Remove reCAPTCHA site key handling

### DIFF
--- a/google-services-plugin/src/main/kotlin/com/google/gms/googleservices/GoogleServicesTask.kt
+++ b/google-services-plugin/src/main/kotlin/com/google/gms/googleservices/GoogleServicesTask.kt
@@ -109,7 +109,6 @@ abstract class GoogleServicesTask : DefaultTask() {
       handleGoogleApiKey(resValues)
       handleGoogleAppId(resValues)
       handleWebClientId(resValues)
-        handleSiteKey(resValues)
     }
         ?: throw GradleException(
             "No matching client found for package name '${applicationId.get()}' in ${quickstartFile.path}")
@@ -259,12 +258,6 @@ abstract class GoogleServicesTask : DefaultTask() {
       }
     }
   }
-
-    fun FirebaseClientData.handleSiteKey(resValues: MutableMap<String, String?>) {
-        this.getAsJsonPrimitive("recaptcha_site_key")?.let {
-            resValues["recaptcha_site_key"] = it.asString
-        }
-    }
 
   /**
    * Handle a client object for analytics (@xml/global_tracker)

--- a/google-services-plugin/src/test/testData/project1-expected/processFreeOneDebugGoogleServices/values/values.xml
+++ b/google-services-plugin/src/test/testData/project1-expected/processFreeOneDebugGoogleServices/values/values.xml
@@ -7,5 +7,4 @@
     <string name="google_app_id" translatable="false">1:123456789000:android:f1bf012572b04063</string>
     <string name="google_crash_reporting_api_key" translatable="false">AIzbSzCn1N6LWIe6wthYyrgUUSAlUsdqMb-wvTo</string>
     <string name="project_id" translatable="false">mockproject-1234</string>
-    <string name="recaptcha_site_key" translatable="false">6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00</string>
 </resources>

--- a/google-services-plugin/src/test/testData/project1-expected/processFreeTwoDebugGoogleServices/values/values.xml
+++ b/google-services-plugin/src/test/testData/project1-expected/processFreeTwoDebugGoogleServices/values/values.xml
@@ -7,5 +7,4 @@
     <string name="google_app_id" translatable="false">1:123456789000:android:f1bf012572b04063</string>
     <string name="google_crash_reporting_api_key" translatable="false">AIzbSzCn1N6LWIe6wthYyrgUUSAlUsdqMb-wvTo</string>
     <string name="project_id" translatable="false">mockproject-1234</string>
-    <string name="recaptcha_site_key" translatable="false">6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00</string>
 </resources>

--- a/google-services-plugin/src/test/testData/project1-expected/processPaidOneDebugGoogleServices/values/values.xml
+++ b/google-services-plugin/src/test/testData/project1-expected/processPaidOneDebugGoogleServices/values/values.xml
@@ -7,5 +7,4 @@
     <string name="google_app_id" translatable="false">1:123456789000:android:f1bf012572b04063</string>
     <string name="google_crash_reporting_api_key" translatable="false">AIzbSzCn1N6LWIe6wthYyrgUUSAlUsdqMb-wvTo</string>
     <string name="project_id" translatable="false">mockproject-1234</string>
-    <string name="recaptcha_site_key" translatable="false">6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00</string>
 </resources>

--- a/google-services-plugin/src/test/testData/project1-expected/processPaidTwoDebugGoogleServices/values/values.xml
+++ b/google-services-plugin/src/test/testData/project1-expected/processPaidTwoDebugGoogleServices/values/values.xml
@@ -7,5 +7,4 @@
     <string name="google_app_id" translatable="false">1:123456789000:android:f1bf012572b04063</string>
     <string name="google_crash_reporting_api_key" translatable="false">AIzbSzCn1N6LWIe6wthYyrgUUSAlUsdqMb-wvTo</string>
     <string name="project_id" translatable="false">mockproject-1234</string>
-    <string name="recaptcha_site_key" translatable="false">6L00000sAAAAAAaaaaaAAaa00000_AAAaAaaAa00</string>
 </resources>


### PR DESCRIPTION
Removed the `handleSiteKey` extension function and its invocation from `GoogleServicesTask`, stopping the generation of the `recaptcha_site_key` resource string. Updated test data expectation XML files to remove `recaptcha_site_key`.